### PR TITLE
Feature/edit release note

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@material-ui/core": "^4.9.1",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.43",
+    "@material-ui/styles": "^4.9.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.4.0",
     "@testing-library/user-event": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "axios": "^0.19.2",
     "draft-js": "^0.11.4",
     "draftjs-to-html": "^0.9.1",
+    "html-to-draftjs": "^1.5.0",
     "immutability-helper": "^3.0.1",
     "immutable": "^4.0.0-rc.12",
     "jest-junit": "^10.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,6 @@
 import React from "react";
-import { BrowserRouter as Router, Route } from "react-router-dom";
+import { BrowserRouter as Router } from "react-router-dom";
 import "./App.css";
-import LandingScreen from "./components/screen/LandingScreen";
-import ReleasesScreen from "./components/screen/ReleasesScreen";
 import Navbar from "./components/Navbar";
 import { ThemeProvider } from "styled-components";
 import { GlobalStyle, theme } from "./styles/index";
@@ -12,22 +10,14 @@ import { store } from "./setupStore";
 import Axios from "axios";
 import "draft-js/dist/Draft.css";
 
-import AdminScreen from "./components/screen/AdminScreen";
-import LoginScreen from "./components/screen/LoginScreen";
 import Footer from "./components/Footer";
 import styled from "styled-components";
-import ArticleScreen from "./components/screen/ArticleScreen";
-import ReleaseEditorScreen from "./components/screen/ReleaseEditorScreen";
-import EditReleaseNoteForm from "./components/ReleaseNoteEditor/EditReleaseNoteForm";
 import { getAuthToken } from "./handlers/cookieHandler";
-import AdminReleaseNotesScreen from "./components/screen/AdminReleaseNotesScreen";
+import EditReleaseNoteScreen from "./components/screen/EditReleaseNoteScreen";
+import Routes from "./components/Routes";
 
 // https://github.com/axios/axios
 Axios.defaults.baseURL = "http://localhost:5000/api/";
-//Axios.defaults.headers.common['Authorization'] = AUTH_TOKEN;
-//Axios.defaults.headers.post['Content-Type'] = 'application/json';
-
-// intercept outgoing and incoming requests for debugging
 Axios.interceptors.request.use(request => {
   const token = getAuthToken();
   if (token) {
@@ -36,11 +26,7 @@ Axios.interceptors.request.use(request => {
   return request;
 });
 
-Axios.interceptors.response.use(response => {
-  return response;
-});
-
-function App() {
+const App = () => {
   return (
     <Provider store={store}>
       <GlobalStyle />
@@ -49,34 +35,14 @@ function App() {
         <ThemeProvider theme={theme}>
           <Navbar />
           <MainContent>
-            <Route path="/" exact component={LandingScreen} />
-            <Route path="/releases" exact component={ReleasesScreen} />
-            <Route path="/articles/article01" exact component={ArticleScreen} />
-            <Route path="/admin/" exact component={AdminScreen} />
-            <Route
-              path="/admin/releasenotes"
-              exact
-              component={AdminReleaseNotesScreen}
-            />
-            <Route
-              path="/admin/releasenotes/:id"
-              exact
-              render={props => <EditReleaseNoteForm {...props} />}
-            />
-            <Route path="/login/" exact component={LoginScreen} />
-            <Route
-              path="/release/editor"
-              exact
-              component={ReleaseEditorScreen}
-            />
-            <Route path="/debug/" exact component={EditReleaseNoteForm} />
+            <Routes />
           </MainContent>
           <Footer />
         </ThemeProvider>
       </Router>
     </Provider>
   );
-}
+};
 
 export default App;
 

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Route } from "react-router-dom";
 import "./App.css";
 import LandingScreen from "./components/screen/LandingScreen";
-import ReleaseNotesScreen from "./components/screen/ReleaseNotesScreen";
+import ReleasesScreen from "./components/screen/ReleasesScreen";
 import Navbar from "./components/Navbar";
 import { ThemeProvider } from "styled-components";
 import { GlobalStyle, theme } from "./styles/index";
@@ -18,6 +18,9 @@ import Footer from "./components/Footer";
 import styled from "styled-components";
 import ArticleScreen from "./components/screen/ArticleScreen";
 import ReleaseEditorScreen from "./components/screen/ReleaseEditorScreen";
+import EditReleaseNoteForm from "./components/ReleaseNoteEditor/EditReleaseNoteForm";
+import { getAuthToken } from "./handlers/cookieHandler";
+import AdminReleaseNotesScreen from "./components/screen/AdminReleaseNotesScreen";
 
 // https://github.com/axios/axios
 Axios.defaults.baseURL = "http://localhost:5000/api/";
@@ -26,6 +29,10 @@ Axios.defaults.baseURL = "http://localhost:5000/api/";
 
 // intercept outgoing and incoming requests for debugging
 Axios.interceptors.request.use(request => {
+  const token = getAuthToken();
+  if (token) {
+    request.headers.Authorization = `Bearer ${token}`;
+  }
   return request;
 });
 
@@ -43,15 +50,26 @@ function App() {
           <Navbar />
           <MainContent>
             <Route path="/" exact component={LandingScreen} />
-            <Route path="/releases" exact component={ReleaseNotesScreen} />
+            <Route path="/releases" exact component={ReleasesScreen} />
             <Route path="/articles/article01" exact component={ArticleScreen} />
-            <Route path="/adminpage/" exact component={AdminScreen} />
+            <Route path="/admin/" exact component={AdminScreen} />
+            <Route
+              path="/admin/releasenotes"
+              exact
+              component={AdminReleaseNotesScreen}
+            />
+            <Route
+              path="/admin/releasenotes/:id"
+              exact
+              render={props => <EditReleaseNoteForm {...props} />}
+            />
             <Route path="/login/" exact component={LoginScreen} />
             <Route
               path="/release/editor"
               exact
               component={ReleaseEditorScreen}
             />
+            <Route path="/debug/" exact component={EditReleaseNoteForm} />
           </MainContent>
           <Footer />
         </ThemeProvider>

--- a/src/actions/releaseNoteActions.js
+++ b/src/actions/releaseNoteActions.js
@@ -37,7 +37,6 @@ export function putReleaseNote(id, note) {
     dispatch(actions.putReleaseNotePending(id));
     return Axios.put("/releasenote/" + id, note)
       .then(response => {
-        console.log(response)
         dispatch(actions.putReleaseNoteSuccess(response.data, id));
       })
       .catch(error => {

--- a/src/actions/releaseNoteActions.js
+++ b/src/actions/releaseNoteActions.js
@@ -1,0 +1,99 @@
+import Axios from "axios";
+
+export const CREATE = "CREATE";
+export const UPDATE = "UPDATE";
+export const DELETE = "DELETE";
+
+export const FETCH_RELEASENOTE_SUCCESS = "FETCH_RELEASENOTE_SUCCESS";
+export const FETCH_RELEASENOTE_PENDING = "FETCH_RELEASENOTE_PENDING";
+export const FETCH_RELEASENOTE_ERROR = "FETCH_RELEASENOTE_ERROR";
+
+export const PUT_RELEASENOTE_SUCCESS = "PUT_RELEASENOTE_SUCCESS";
+export const PUT_RELEASENOTE_PENDING = "PUT_RELEASENOTE_PENDING";
+export const PUT_RELEASENOTE_ERROR = "PUT_RELEASENOTE_ERROR";
+
+export function updateArticle(payload) {
+  return {
+    type: UPDATE,
+    payload: payload
+  };
+}
+
+export function fetchReleaseNote(id) {
+  return dispatch => {
+    dispatch(actions.fetchReleaseNotePending(id));
+    return Axios.get("/releasenote/" + id)
+      .then(response => {
+        dispatch(actions.fetchReleaseNoteSuccess(response.data, id));
+      })
+      .catch(error => {
+        actions.fetchReleaseNoteError(error, id);
+      });
+  };
+}
+
+export function putReleaseNote(note) {
+  const id = note.id;
+  return dispatch => {
+    dispatch(actions.putReleaseNotePending(id));
+    return Axios.put("/releasenote/" + id, note)
+      .then(response => {
+        dispatch(actions.putReleaseNoteSuccess(response.data, id));
+      })
+      .catch(error => {
+        actions.putReleaseNoteError(error, id);
+      });
+  };
+}
+
+export const actions = {
+  fetchReleaseNotePending(id) {
+    return {
+      type: FETCH_RELEASENOTE_PENDING,
+      id
+    };
+  },
+
+  fetchReleaseNoteSuccess(response, id) {
+    return {
+      type: FETCH_RELEASENOTE_SUCCESS,
+      payload: response,
+      id
+    };
+  },
+
+  fetchReleaseNoteError(error, id) {
+    return {
+      type: FETCH_RELEASENOTE_ERROR,
+      payload: error,
+      id
+    };
+  },
+
+  putReleaseNotePending(id) {
+    return {
+      type: FETCH_RELEASENOTE_PENDING,
+      id
+    };
+  },
+
+  putReleaseNoteSuccess(response, id) {
+    return {
+      type: FETCH_RELEASENOTE_SUCCESS,
+      payload: response,
+      id
+    };
+  },
+
+  putReleaseNoteError(error, id) {
+    return {
+      type: FETCH_RELEASENOTE_ERROR,
+      payload: error,
+      id
+    };
+  }
+};
+
+// expmple thunk/axios action
+// https://github.com/axios/axios
+// https://github.com/reduxjs/redux-thunk

--- a/src/actions/releaseNoteActions.js
+++ b/src/actions/releaseNoteActions.js
@@ -32,12 +32,12 @@ export function fetchReleaseNote(id) {
   };
 }
 
-export function putReleaseNote(note) {
-  const id = note.id;
+export function putReleaseNote(id, note) {
   return dispatch => {
     dispatch(actions.putReleaseNotePending(id));
     return Axios.put("/releasenote/" + id, note)
       .then(response => {
+        console.log(response)
         dispatch(actions.putReleaseNoteSuccess(response.data, id));
       })
       .catch(error => {
@@ -72,14 +72,14 @@ export const actions = {
 
   putReleaseNotePending(id) {
     return {
-      type: FETCH_RELEASENOTE_PENDING,
+      type: PUT_RELEASENOTE_PENDING,
       id
     };
   },
 
   putReleaseNoteSuccess(response, id) {
     return {
-      type: FETCH_RELEASENOTE_SUCCESS,
+      type: PUT_RELEASENOTE_SUCCESS,
       payload: response,
       id
     };
@@ -87,7 +87,7 @@ export const actions = {
 
   putReleaseNoteError(error, id) {
     return {
-      type: FETCH_RELEASENOTE_ERROR,
+      type: PUT_RELEASENOTE_ERROR,
       payload: error,
       id
     };

--- a/src/components/ReleaseNoteEditor/ComposedEditorsView.jsx
+++ b/src/components/ReleaseNoteEditor/ComposedEditorsView.jsx
@@ -1,12 +1,12 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Editor, EditorState } from "draft-js";
-import { Paper } from "@material-ui/core";
+import { Paper, Typography } from "@material-ui/core";
 import styled from "styled-components";
 import { Map } from "immutable";
 import { Editor as EditorWysiwyg } from "react-draft-wysiwyg";
+import PropTypes from "prop-types";
 
 const ComposedEditorsView = props => {
-
   const titleRenderMap = Map({
     unstyled: {
       element: "h2"
@@ -27,6 +27,14 @@ const ComposedEditorsView = props => {
   return (
     <Paper variant="outlined">
       <EditorInner>
+        <Typography
+          style={{ fontSize: 12 }}
+          display="block"
+          color="textSecondary"
+          gutterBottom
+        >
+          Forhåndsvisning
+        </Typography>
         {props.title.getCurrentContent().hasText() ? (
           <Editor
             editorState={EditorState.createWithContent(
@@ -77,7 +85,12 @@ ComposedEditorsView.defaultProps = {
   description: EditorState.createEmpty()
 };
 
+ComposedEditorsView.defaultProps = {
+  title: PropTypes.object,
+  ingress: PropTypes.object,
+  description: PropTypes.object
+};
+
 const EditorInner = styled.div`
   margin: 14px 18.5px;
 `;
-

--- a/src/components/ReleaseNoteEditor/ComposedEditorsView.jsx
+++ b/src/components/ReleaseNoteEditor/ComposedEditorsView.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Editor, EditorState } from "draft-js";
 import { Paper } from "@material-ui/core";
 import styled from "styled-components";
@@ -6,6 +6,7 @@ import { Map } from "immutable";
 import { Editor as EditorWysiwyg } from "react-draft-wysiwyg";
 
 const ComposedEditorsView = props => {
+
   const titleRenderMap = Map({
     unstyled: {
       element: "h2"

--- a/src/components/ReleaseNoteEditor/EditReleaseNoteForm.jsx
+++ b/src/components/ReleaseNoteEditor/EditReleaseNoteForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import {
   Paper,
   Box,
@@ -6,14 +6,12 @@ import {
   Switch,
   FormControlLabel,
   Divider,
-  Typography,
   CardActionArea,
   AppBar,
   Toolbar
 } from "@material-ui/core";
 import styled from "styled-components";
 import ComposedEditorsView from "./ComposedEditorsView";
-import PageContainer from "../shared/PageContainer";
 import ReleaseNoteInput from "./ReleaseNoteInput";
 import ReleaseNoteRichInput from "./ReleaseNoteRichInput";
 import "draft-js/dist/Draft.css";
@@ -29,30 +27,21 @@ import {
 import { Assignment, Person } from "@material-ui/icons";
 
 const EditReleaseNoteForm = props => {
-  console.log(props)
-  /*
-  const dispatch = useDispatch();
-  useEffect(() => {
-    dispatch(fetchReleaseNote(1));
-  }, []);
-  const note = useSelector(state => state.releaseNotes.items[0]);
-  */
-
   const [title, setTitle] = React.useState(
     RichUtils.toggleBlockType(
-      createStateFromText(props.note.title),
+      createStateFromText(props.note.item.title),
       "header-two"
     )
   );
 
   const [ingress, setIngress] = React.useState(
     RichUtils.toggleInlineStyle(
-      createStateFromText(props.note.ingress),
+      createStateFromText(props.note.item.ingress),
       "ITALIC"
     )
   );
   const [description, setDescription] = React.useState(
-    createStateFromText(props.note.description)
+    createStateFromText(props.note.item.description)
   );
   const [ready, setReady] = React.useState();
 
@@ -148,7 +137,7 @@ const EditReleaseNoteForm = props => {
                 <Box my={1} mx={4} display="flex" alignItems="center">
                   <Box display="flex" alignItems="center">
                     <Assignment display="flex" fontSize="small" />
-                    Task {props.note.workItemId}
+                    Task {props.note.item.workItemId}
                   </Box>
                   <Box
                     display="flex"
@@ -156,21 +145,21 @@ const EditReleaseNoteForm = props => {
                     fontWeight={500}
                     ml={1}
                   >
-                    {props.note.workItemTitle}
+                    {props.note.item.workItemTitle}
                   </Box>
                 </Box>
                 <Box mx={4} mb={1} display="flex" alignItems="center">
                   <Person fontSize="small" />
-                  {props.note.authorName}
+                  {props.note.item.authorName}
                 </Box>
               </CardActionArea>
 
               <Divider />
               <Box m={4}>
-                {props.note.workItemDescriptionHtml ? (
+                {props.note.item.workItemDescriptionHtml ? (
                   <div
                     dangerouslySetInnerHTML={{
-                      __html: props.note.workItemDescriptionHtml
+                      __html: props.note.item.workItemDescriptionHtml
                     }}
                   />
                 ) : (
@@ -219,6 +208,10 @@ const EditReleaseNoteForm = props => {
 
 export default EditReleaseNoteForm;
 
+EditReleaseNoteForm.defaultProps = {
+  note: { error: "note is undefined" }
+};
+
 EditReleaseNoteForm.propTypes = {
   onSave: PropTypes.func,
   note: PropTypes.object
@@ -226,13 +219,6 @@ EditReleaseNoteForm.propTypes = {
 
 const StyledFormControlLabel = styled(FormControlLabel)`
   padding: 0 16px;
-`;
-
-
-const StyledBox = styled(Box)`
-  && {
-    vertical-align: middle;
-  }
 `;
 
 const SaveButton = styled(Button)`

--- a/src/components/ReleaseNoteEditor/EditReleaseNoteForm.jsx
+++ b/src/components/ReleaseNoteEditor/EditReleaseNoteForm.jsx
@@ -6,9 +6,9 @@ import {
   Switch,
   FormControlLabel,
   Divider,
-  CardActionArea,
   AppBar,
-  Toolbar
+  Toolbar,
+  Typography
 } from "@material-ui/core";
 import styled from "styled-components";
 import ComposedEditorsView from "./ComposedEditorsView";
@@ -62,7 +62,6 @@ const EditReleaseNoteForm = props => {
       return EditorState.createEmpty();
     }
     const blocksFromHTML = convertFromHTML(text);
-    console.log(blocksFromHTML);
     const contentState = ContentState.createFromBlockArray(
       blocksFromHTML.contentBlocks,
       blocksFromHTML.entityMap
@@ -105,7 +104,7 @@ const EditReleaseNoteForm = props => {
         <ToolbarWrapper>
           <StyledToolbar disableGutters variant="dense">
             <CancelButton color="secondary" onClick={props.onCancel}>
-              Avbryt
+              Tilbake
             </CancelButton>
             <div>
               <StyledFormControlLabel
@@ -133,29 +132,31 @@ const EditReleaseNoteForm = props => {
         <Box>
           <div>
             <Paper variant="outlined">
-              <CardActionArea>
-                <Box my={1} mx={4} display="flex" alignItems="center">
+              <Box my={1} mx={3}>
+                <Typography
+                  style={{ fontSize: 12 }}
+                  display="block"
+                  color="textSecondary"
+                  gutterBottom
+                >
+                  Work item
+                </Typography>
+                <Box display="flex" alignItems="center">
                   <Box display="flex" alignItems="center">
                     <Assignment display="flex" fontSize="small" />
                     Task {props.note.item.workItemId}
                   </Box>
-                  <Box
-                    display="flex"
-                    alignItems="center"
-                    fontWeight={500}
-                    ml={1}
-                  >
-                    {props.note.item.workItemTitle}
+                  <Box display="flex" alignItems="center" ml={2}>
+                    <Typography>{props.note.item.workItemTitle}</Typography>
+                  </Box>
+                  <Box display="flex" alignItems="center" ml={2}>
+                    <Person fontSize="small" />
+                    {props.note.item.authorName}
                   </Box>
                 </Box>
-                <Box mx={4} mb={1} display="flex" alignItems="center">
-                  <Person fontSize="small" />
-                  {props.note.item.authorName}
-                </Box>
-              </CardActionArea>
-
+              </Box>
               <Divider />
-              <Box m={4}>
+              <Box m={3}>
                 {props.note.item.workItemDescriptionHtml ? (
                   <div
                     dangerouslySetInnerHTML={{
@@ -193,7 +194,6 @@ const EditReleaseNoteForm = props => {
           </div>
 
           <Box mt={5} mb={4}>
-            <p>Forhåndsvisning</p>
             <ComposedEditorsView
               title={title}
               ingress={ingress}
@@ -209,7 +209,7 @@ const EditReleaseNoteForm = props => {
 export default EditReleaseNoteForm;
 
 EditReleaseNoteForm.defaultProps = {
-  note: { error: "note is undefined" }
+  note: { item: { error: "note is undefined" } }
 };
 
 EditReleaseNoteForm.propTypes = {

--- a/src/components/ReleaseNoteEditor/EditReleaseNoteForm.jsx
+++ b/src/components/ReleaseNoteEditor/EditReleaseNoteForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 import {
   Paper,
   Box,
@@ -37,30 +37,35 @@ import {
   Error
 } from "@material-ui/icons";
 import { green, orange } from "@material-ui/core/colors";
+import BottomToolbar from "../shared/BottomToolbar";
 
 const EditReleaseNoteForm = props => {
+  //editor states
   const [title, setTitle] = React.useState(
     RichUtils.toggleBlockType(EditorState.createEmpty(), "header-two")
   );
-
   const [ingress, setIngress] = React.useState(
     RichUtils.toggleInlineStyle(EditorState.createEmpty(), "ITALIC")
   );
   const [description, setDescription] = React.useState(
     EditorState.createEmpty()
   );
+
+  // ready for release switch
   const [ready, setReady] = React.useState();
+
+  // saved / changed indicator
   const [changed, setChanged] = React.useState();
 
+  // initalize editors with loaded data
   useEffect(() => {
-    // initalize editors with loaded data
     setTitle(createStateFromText(props.note.item.title));
     setIngress(createStateFromText(props.note.item.ingress));
     setDescription(createStateFromText(props.note.item.description));
   }, [props.note.item]);
 
+  // update the given editor
   const handleEditorChange = (source, editorState) => {
-    // update the given editor
     switch (source) {
       case "INGRESS":
         doUpdateEditor(setIngress, ingress, editorState);
@@ -76,7 +81,6 @@ const EditReleaseNoteForm = props => {
         break;
     }
   };
-
   function doUpdateEditor(setState, oldState, newState) {
     if (newState.getCurrentContent() !== oldState.getCurrentContent()) {
       setChanged(true);
@@ -123,7 +127,7 @@ const EditReleaseNoteForm = props => {
   };
 
   const handleReady = ev => {
-    // "ready for release" toggle
+    // "ready for release" switch handler
     setReady(!ready);
   };
 
@@ -131,67 +135,59 @@ const EditReleaseNoteForm = props => {
     // editor contents are saved
     setChanged(false);
   }, [props.note.updated]);
-  console.log(props.note)
+
   return (
     <React.Fragment>
-      <BottomAppBar>
-        <Fade
-          in={props.note.pending}
-          style={{
-            transitionDelay: props.note.pending ? "800ms" : "0ms"
-          }}
-        >
-          <LinearProgress />
-        </Fade>
-        <ToolbarWrapper>
-          <StyledToolbar disableGutters variant="dense">
-            <CancelButton color="secondary" onClick={props.onCancel}>
-              Tilbake
-            </CancelButton>
-            <div>
-              <StyledFormControlLabel
-                edge="end"
-                control={
-                  <Switch
-                    checked={ready}
-                    size="small"
-                    onChange={handleReady}
-                    value="ready"
-                    color="primary"
-                    inputProps={{ "aria-label": "primary checkbox" }}
-                  />
-                }
-                label="Klar for release"
+      <BottomToolbar
+        loading={props.note.pending}
+        left={[
+          <CancelButton color="secondary" onClick={props.onCancel}>
+            Tilbake
+          </CancelButton>
+        ]}
+        right={[
+          <StyledFormControlLabel
+            edge="end"
+            control={
+              <Switch
+                checked={ready}
+                size="small"
+                onChange={handleReady}
+                value="ready"
+                color="primary"
+                inputProps={{ "aria-label": "primary checkbox" }}
               />
-              <SaveButton
-                onClick={handleSave}
-                disabled={canSave()}
-                startIcon={<Save />}
-              >
-                Lagre
-              </SaveButton>
-              <IconButton disableRipple>
-                {props.note.error ? (
-                  <Tooltip title="En feil oppstod når du prøvde å lagre endringene">
-                    <Error />
-                  </Tooltip>
-                ) : changed ? (
-                  <Tooltip title="Du har ulagrede endringer">
-                    <FiberManualRecord
-                      size="small"
-                      style={{ color: orange[500], opacity: "0.7" }}
-                    />
-                  </Tooltip>
-                ) : (
-                  <Tooltip title="Endringene er lagret">
-                    <Check style={{ color: green[500] }} />
-                  </Tooltip>
-                )}
-              </IconButton>
-            </div>
-          </StyledToolbar>
-        </ToolbarWrapper>
-      </BottomAppBar>
+            }
+            label="Klar for release"
+          />,
+          <SaveButton
+            onClick={handleSave}
+            disabled={canSave()}
+            startIcon={<Save />}
+          >
+            Lagre
+          </SaveButton>,
+          <IconButton disableRipple>
+            {props.note.error ? (
+              <Tooltip title="En feil oppstod når du prøvde å lagre endringene">
+                <Error />
+              </Tooltip>
+            ) : changed ? (
+              <Tooltip title="Du har ulagrede endringer">
+                <FiberManualRecord
+                  size="small"
+                  style={{ color: orange[500], opacity: "0.7" }}
+                />
+              </Tooltip>
+            ) : (
+              <Tooltip title="Endringene er lagret">
+                <Check style={{ color: green[500] }} />
+              </Tooltip>
+            )}
+          </IconButton>
+        ]}
+      />
+
       <form>
         <Box>
           <div>
@@ -296,11 +292,6 @@ const SaveButton = styled(Button)`
   }
 `;
 
-const ToolbarWrapper = styled.div`
-  width: ${props => props.theme.contentWidth};
-  max-width: ${props => props.theme.contentWidth};
-  margin: auto;
-`;
 const StyledToolbar = styled(Toolbar)`
   justify-content: space-between;
 `;
@@ -311,7 +302,11 @@ const CancelButton = styled(Button)`
     padding: 0 16px;
   }
 `;
-
+const ToolbarWrapper = styled.div`
+  width: ${props => props.theme.contentWidth};
+  max-width: ${props => props.theme.contentWidth};
+  margin: auto;
+`;
 const BottomAppBar = styled(AppBar)`
   & {
     background-color: ${props => props.theme.mainColor} !important;

--- a/src/components/ReleaseNoteEditor/EditReleaseNoteForm.jsx
+++ b/src/components/ReleaseNoteEditor/EditReleaseNoteForm.jsx
@@ -6,13 +6,9 @@ import {
   Switch,
   FormControlLabel,
   Divider,
-  AppBar,
-  Toolbar,
   Typography,
   Tooltip,
   IconButton,
-  LinearProgress,
-  Fade
 } from "@material-ui/core";
 import styled from "styled-components";
 import ComposedEditorsView from "./ComposedEditorsView";
@@ -292,26 +288,9 @@ const SaveButton = styled(Button)`
   }
 `;
 
-const StyledToolbar = styled(Toolbar)`
-  justify-content: space-between;
-`;
-
 const CancelButton = styled(Button)`
   && {
     color: white;
     padding: 0 16px;
-  }
-`;
-const ToolbarWrapper = styled.div`
-  width: ${props => props.theme.contentWidth};
-  max-width: ${props => props.theme.contentWidth};
-  margin: auto;
-`;
-const BottomAppBar = styled(AppBar)`
-  & {
-    background-color: ${props => props.theme.mainColor} !important;
-    position: fixed;
-    top: auto !important;
-    bottom: 0 !important;
   }
 `;

--- a/src/components/ReleaseNoteEditor/ReleaseNoteInput.jsx
+++ b/src/components/ReleaseNoteEditor/ReleaseNoteInput.jsx
@@ -6,9 +6,6 @@ import { Editor } from "react-draft-wysiwyg";
 import styled from "styled-components";
 
 const ReleaseNoteInput = props => {
-  function handleClearInput() {
-    props.onChange(EditorState.createEmpty());
-  }
 
   const onEditorChange = editorState => {
     props.onChange(editorState);

--- a/src/components/ReleaseNoteEditor/ReleaseNoteInput.jsx
+++ b/src/components/ReleaseNoteEditor/ReleaseNoteInput.jsx
@@ -15,7 +15,6 @@ const ReleaseNoteInput = props => {
   };
 
   let editor = React.createRef();
-
   const focusEditor = () => {
     editor.current.focusEditor();
   };

--- a/src/components/ReleaseNoteEditor/ReleaseNoteRichInput.jsx
+++ b/src/components/ReleaseNoteEditor/ReleaseNoteRichInput.jsx
@@ -1,7 +1,5 @@
-import React, { useState } from "react";
+import React from 'react';
 import { FormControl, Divider } from "@material-ui/core";
-
-import { EditorState } from "draft-js";
 import { Editor } from "react-draft-wysiwyg";
 import "react-draft-wysiwyg/dist/react-draft-wysiwyg.css";
 import styled from "styled-components";

--- a/src/components/ReleaseNoteEditor/ReleaseNoteRichInput.jsx
+++ b/src/components/ReleaseNoteEditor/ReleaseNoteRichInput.jsx
@@ -7,36 +7,20 @@ import "react-draft-wysiwyg/dist/react-draft-wysiwyg.css";
 import styled from "styled-components";
 
 const ReleaseNoteRichInput = props => {
-  const [editorState, setEditorState] = useState(EditorState.createEmpty());
-
   let editor = React.createRef();
 
   const focusEditor = () => {
     editor.current.focusEditor();
   };
-  /*const handleFormat = (event, newFormats) => {
-    // https://stackoverflow.com/questions/1187518/how-to-get-the-difference-between-two-arrays-in-javascript
-    let diff = newFormats
-      .filter(format => !formats.includes(format))
-      .concat(formats.filter(formats => !newFormats.includes(formats)));
-    setFormats(newFormats);
-    for (const format of diff) {
-      onEditorChange(RichUtils.toggleInlineStyle(editorState, format));
-    }
 
-    // TODO: currently only applies to selected text
-  };*/
   const onEditorChange = editorState => {
-    setEditorState(editorState);
     props.onChange(editorState);
   };
 
   const handleImageUpload = image => {
-    return new Promise(
-      (resolve, reject) => {
-        resolve({data: {link: URL.createObjectURL(image)}});
-      }
-    );
+    return new Promise((resolve, reject) => {
+      resolve({ data: { link: URL.createObjectURL(image) } });
+    });
   };
 
   return (
@@ -47,8 +31,11 @@ const ReleaseNoteRichInput = props => {
           <Editor
             placeholder="Beskrivelse"
             ref={editor}
-            editorState={editorState}
+            editorState={props.editorState}
             onEditorStateChange={onEditorChange}
+            editorStyle={{
+              padding: "14px 18.5px"
+            }}
             editorClassName={"editor"}
             toolbarClassName={"toolbar"}
             toolbar={{

--- a/src/components/Routes.jsx
+++ b/src/components/Routes.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Route, useHistory } from "react-router";
+import LandingScreen from "./screen/LandingScreen";
+import ReleasesScreen from "./screen/ReleasesScreen";
+import ArticleScreen from "./screen/ArticleScreen";
+import AdminScreen from "./screen/AdminScreen";
+import AdminReleaseNotesScreen from "./screen/AdminReleaseNotesScreen";
+import EditReleaseNoteScreen from "./screen/EditReleaseNoteScreen";
+import LoginScreen from "./screen/LoginScreen";
+import ReleaseEditorScreen from "./screen/ReleaseEditorScreen";
+import Axios from "axios";
+
+const Routes = () => {
+  const history = useHistory();
+  Axios.interceptors.response.use(
+    response => {
+      return response;
+    },
+    error => {
+      if (error.response.status === 401) {
+        history.push("/login");
+      }
+      return Promise.reject(error.response);
+    }
+  );
+  return (
+    <React.Fragment>
+      <Route path="/" exact component={LandingScreen} />
+      <Route path="/releases" exact component={ReleasesScreen} />
+      <Route path="/articles/article01" exact component={ArticleScreen} />
+      <Route path="/admin/" exact component={AdminScreen} />
+      <Route
+        path="/admin/releasenotes"
+        exact
+        component={AdminReleaseNotesScreen}
+      />
+      <Route
+        path="/admin/releasenotes/:id"
+        exact
+        render={props => <EditReleaseNoteScreen {...props} />}
+      />
+      <Route path="/login/" exact component={LoginScreen} />
+      <Route path="/release/editor" exact component={ReleaseEditorScreen} />
+    </React.Fragment>
+  );
+};
+
+export default Routes;

--- a/src/components/screen/AdminReleaseNotesScreen.jsx
+++ b/src/components/screen/AdminReleaseNotesScreen.jsx
@@ -28,25 +28,25 @@ const AdminReleaseNotesScreen = () => {
       workItemTitle: "Release Note 5",
       ingress:
         "In this release note we wrote everything we did to make things better",
-      id: "5"
+      id: "4"
     },
     {
       workItemTitle: "Release Note 6",
       ingress:
         "In this release note we wrote everything we did to make things better",
-      id: "6"
+      id: "1"
     },
     {
       workItemTitle: "Release Note 7",
       ingress:
         "In this release note we wrote everything we did to make things better",
-      id: "7"
+      id: "2"
     },
     {
       workItemTitle: "Release Note 8",
       ingress:
         "In this release note we wrote everything we did to make things better",
-      id: "8"
+      id: "3"
     }
   ];
 

--- a/src/components/screen/AdminReleaseNotesScreen.jsx
+++ b/src/components/screen/AdminReleaseNotesScreen.jsx
@@ -7,7 +7,6 @@ import {
   IconButton,
   TableBody,
   TableRow,
-  Button,
   TableCell,
   TableContainer,
   Table,
@@ -19,10 +18,8 @@ import { green, red } from "@material-ui/core/colors";
 import { useHistory } from "react-router";
 
 const AdminReleaseNotesScreen = () => {
-  const [open, setOpen] = React.useState();
   //const releaseNotes = useSelector(state => state.releaseNotes.items);
   // dummy data
-
   const releaseNotes = [
     {
       workItemTitle: "Release Note 5",
@@ -133,27 +130,10 @@ const AdminReleaseNotesScreen = () => {
 };
 export default AdminReleaseNotesScreen;
 
-const AddButton = styled(Button)`
-  && {
-    align-self: end;
-    margin-left: auto;
-    margin-right: 2rem;
-  }
-`;
-
 const StyledTableCell = styled(TableCell)`
   width: 0;
 `;
 
-const TablePanel = styled.div`
-  display: flex;
-`;
-
 const EditButton = styled(Edit)`
   margin-left: auto;
-`;
-
-const ErrorLabel = styled.div`
-  text-align: center;
-  margin: 16px;
 `;

--- a/src/components/screen/AdminReleaseNotesScreen.jsx
+++ b/src/components/screen/AdminReleaseNotesScreen.jsx
@@ -1,0 +1,159 @@
+import React from "react";
+import PageContainer from "../shared/PageContainer";
+import ScreenTitle from "../shared/ScreenTitle";
+import Ingress from "../shared/Ingress";
+import SpacedDivider from "../shared/SpacedDivider";
+import {
+  IconButton,
+  TableBody,
+  TableRow,
+  Button,
+  TableCell,
+  TableContainer,
+  Table,
+  TableHead,
+} from "@material-ui/core";
+import { Edit, Block, Check } from "@material-ui/icons";
+import styled from "styled-components";
+import { green, red } from "@material-ui/core/colors";
+import { useHistory } from "react-router";
+
+const AdminReleaseNotesScreen = () => {
+  const [open, setOpen] = React.useState();
+  //const releaseNotes = useSelector(state => state.releaseNotes.items);
+  // dummy data
+
+  const releaseNotes = [
+    {
+      workItemTitle: "Release Note 5",
+      ingress:
+        "In this release note we wrote everything we did to make things better",
+      id: "5"
+    },
+    {
+      workItemTitle: "Release Note 6",
+      ingress:
+        "In this release note we wrote everything we did to make things better",
+      id: "6"
+    },
+    {
+      workItemTitle: "Release Note 7",
+      ingress:
+        "In this release note we wrote everything we did to make things better",
+      id: "7"
+    },
+    {
+      workItemTitle: "Release Note 8",
+      ingress:
+        "In this release note we wrote everything we did to make things better",
+      id: "8"
+    }
+  ];
+
+  const columns = [
+    { id: "ready", label: "Klar" },
+    { id: "name", label: "Name", align: "left" },
+    {
+      id: "button",
+      label: "",
+      minWidth: 170,
+      align: "right",
+      format: value => value.toFixed(2)
+    }
+  ];
+
+  const history = useHistory();
+  const handleEditReleaseNote = id => {
+    history.push("/admin/releasenotes/" + id);
+  };
+
+  return (
+    <PageContainer>
+      <ScreenTitle>ADMINPANEL</ScreenTitle>
+      <Ingress gutterBottom>Rediger release notes.</Ingress>
+      <SpacedDivider />
+
+      <TableContainer>
+        <Table>
+          <TableHead>
+            <TableRow>
+              {columns.map(column => (
+                <TableCell key={column.id} align={column.align}>
+                  {column.label}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {releaseNotes.map(note => {
+              return (
+                <TableRow
+                  hover
+                  role="checkbox"
+                  tabIndex={-1}
+                  key={note.workItemTitle}
+                >
+                  {columns.map(column => {
+                    if (column.id === "button") {
+                      return (
+                        <StyledTableCell>
+                          <IconButton
+                            onClick={() => handleEditReleaseNote(note.id)}
+                          >
+                            <EditButton fontSize="small" />
+                          </IconButton>
+                        </StyledTableCell>
+                      );
+                    } else if (column.id === "name") {
+                      return (
+                        <TableCell key={column.id} align={column.align}>
+                          {note.workItemTitle}
+                        </TableCell>
+                      );
+                    } else if (column.id === "ready") {
+                      return (
+                        <StyledTableCell key={column.id} align={column.align}>
+                          {note.ready ? (
+                            <Check style={{ color: green[500] }} />
+                          ) : (
+                            <Block style={{ color: red[200] }} />
+                          )}
+                        </StyledTableCell>
+                      );
+                    }
+                  })}
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </PageContainer>
+  );
+};
+export default AdminReleaseNotesScreen;
+
+const AddButton = styled(Button)`
+  && {
+    align-self: end;
+    margin-left: auto;
+    margin-right: 2rem;
+  }
+`;
+
+const StyledTableCell = styled(TableCell)`
+  width: 0;
+`;
+
+const TablePanel = styled.div`
+  display: flex;
+`;
+
+const EditButton = styled(Edit)`
+  margin-left: auto;
+`;
+
+const ErrorLabel = styled.div`
+  text-align: center;
+  margin: 16px;
+`;

--- a/src/components/screen/AdminScreen.jsx
+++ b/src/components/screen/AdminScreen.jsx
@@ -1,5 +1,5 @@
 import React, { Component, useEffect } from "react";
-import { Container } from "@material-ui/core";
+import { Container, Button, Box } from "@material-ui/core";
 import { PermIdentity, DesktopWindows, Description } from "@material-ui/icons";
 import PageContainer from "../shared/PageContainer";
 import Ingress from "../shared/Ingress";
@@ -11,9 +11,14 @@ import AdminExpansionPanel from "../shared/AdminExpansionPanel";
 import { useSelector, useDispatch } from "react-redux";
 import { fetchProducts } from "../../actions/productActions";
 import { fetchArticles } from "../../actions/articleActions";
+import styled from "styled-components";
+import { useHistory } from "react-router";
+import AdminReleaseNotesScreen from "./AdminReleaseNotesScreen";
+import { BrowserRouter as Route } from "react-router-dom";
 
 const AdminScreen = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
   useEffect(() => {
     dispatch(fetchProducts());
   }, []);
@@ -32,6 +37,10 @@ const AdminScreen = () => {
   const productTitles = useSelector(state =>
     state.products.items.map(p => createData(p.name))
   );
+
+  const handleEditReleaseNotes = () => {
+    history.push("/admin/releasenotes");
+  };
 
   const dummyUsers = [
     createData("Michael Jackson"),
@@ -66,9 +75,26 @@ const AdminScreen = () => {
           //createContentComponent={<AddReleaseForm />}
           //editContentComponent={<AddReleaseForm />}
         />
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleEditReleaseNotes}
+        >
+          Release Notes
+        </Button>
       </Container>
     </PageContainer>
   );
 };
 
 export default AdminScreen;
+
+const StyledBox = styled(Box)`
+  & {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 24px 0;
+    min-height: 48px;
+  }
+`;

--- a/src/components/screen/AdminScreen.jsx
+++ b/src/components/screen/AdminScreen.jsx
@@ -1,4 +1,4 @@
-import React, { Component, useEffect } from "react";
+import React, { useEffect } from "react";
 import { Container, Button, Box } from "@material-ui/core";
 import { PermIdentity, DesktopWindows, Description } from "@material-ui/icons";
 import PageContainer from "../shared/PageContainer";
@@ -13,8 +13,6 @@ import { fetchProducts } from "../../actions/productActions";
 import { fetchArticles } from "../../actions/articleActions";
 import styled from "styled-components";
 import { useHistory } from "react-router";
-import AdminReleaseNotesScreen from "./AdminReleaseNotesScreen";
-import { BrowserRouter as Route } from "react-router-dom";
 
 const AdminScreen = () => {
   const dispatch = useDispatch();
@@ -88,13 +86,3 @@ const AdminScreen = () => {
 };
 
 export default AdminScreen;
-
-const StyledBox = styled(Box)`
-  & {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 24px 0;
-    min-height: 48px;
-  }
-`;

--- a/src/components/screen/EditReleaseNoteScreen.jsx
+++ b/src/components/screen/EditReleaseNoteScreen.jsx
@@ -1,22 +1,28 @@
-import React from "react";
+import React, { useEffect } from "react";
 import EditReleaseNoteForm from "../ReleaseNoteEditor/EditReleaseNoteForm";
-import { Box } from "@material-ui/core";
+import { Box, LinearProgress } from "@material-ui/core";
 import { useHistory } from "react-router";
-import { putReleaseNote } from "../../actions/releaseNoteActions";
+import {
+  putReleaseNote,
+  fetchReleaseNote
+} from "../../actions/releaseNoteActions";
+import { useDispatch, useSelector } from "react-redux";
+import PageContainer from "../shared/PageContainer";
 
 const EditReleaseNoteScreen = props => {
-  const id = props.params.id;
+  const id = props.match.params.id;
   const history = useHistory();
   const dispatch = useDispatch();
 
-  const note = state.items.findIndex(r => r.item.id === id);
-  console.log(note)
+  const note = useSelector(state =>
+    state.releaseNotes.items.find(r => r.item.id == id)
+  );
+
   useEffect(() => {
-    console.log("Note: " + note);
     if (!note) {
       dispatch(fetchReleaseNote(id));
     }
-  }, []);
+  }, [id, dispatch, note]);
 
   const handleSave = objectToSave => {
     dispatch(putReleaseNote(objectToSave));
@@ -24,14 +30,25 @@ const EditReleaseNoteScreen = props => {
   const handleCancel = () => {
     history.goBack();
   };
+
+  console.log(note);
+
   return (
-    <PageContainer>
-        <EditReleaseNoteForm
-          note={note}
-          onSave={handleSave}
-          onCancel={handleCancel}
-        />
-    </PageContainer>
+    <React.Fragment>
+      {note && note.pending && !note.item ? (
+        <LinearProgress />
+      ) : (
+        <PageContainer>
+          <Box my={5}>
+            <EditReleaseNoteForm
+              note={note}
+              onSave={handleSave}
+              onCancel={handleCancel}
+            />
+          </Box>
+        </PageContainer>
+      )}
+    </React.Fragment>
   );
 };
 

--- a/src/components/screen/EditReleaseNoteScreen.jsx
+++ b/src/components/screen/EditReleaseNoteScreen.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import EditReleaseNoteForm from "../ReleaseNoteEditor/EditReleaseNoteForm";
+import { Box } from "@material-ui/core";
+import { useHistory } from "react-router";
+import { putReleaseNote } from "../../actions/releaseNoteActions";
+
+const EditReleaseNoteScreen = props => {
+  const id = props.params.id;
+  const history = useHistory();
+  const dispatch = useDispatch();
+
+  const note = state.items.findIndex(r => r.item.id === id);
+  console.log(note)
+  useEffect(() => {
+    console.log("Note: " + note);
+    if (!note) {
+      dispatch(fetchReleaseNote(id));
+    }
+  }, []);
+
+  const handleSave = objectToSave => {
+    dispatch(putReleaseNote(objectToSave));
+  };
+  const handleCancel = () => {
+    history.goBack();
+  };
+  return (
+    <PageContainer>
+        <EditReleaseNoteForm
+          note={note}
+          onSave={handleSave}
+          onCancel={handleCancel}
+        />
+    </PageContainer>
+  );
+};
+
+export default EditReleaseNoteScreen;

--- a/src/components/screen/EditReleaseNoteScreen.jsx
+++ b/src/components/screen/EditReleaseNoteScreen.jsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import EditReleaseNoteForm from "../ReleaseNoteEditor/EditReleaseNoteForm";
-import { Box, LinearProgress } from "@material-ui/core";
+import { Box, LinearProgress, Zoom } from "@material-ui/core";
 import { useHistory } from "react-router";
 import {
   putReleaseNote,
@@ -22,32 +22,27 @@ const EditReleaseNoteScreen = props => {
     if (!note) {
       dispatch(fetchReleaseNote(id));
     }
-  }, [id, dispatch, note]);
+  }, []);
 
   const handleSave = objectToSave => {
-    dispatch(putReleaseNote(objectToSave));
+    dispatch(putReleaseNote(id, objectToSave));
   };
+
   const handleCancel = () => {
     history.goBack();
   };
 
-  console.log(note);
-
   return (
     <React.Fragment>
-      {note && note.pending && !note.item ? (
-        <LinearProgress />
-      ) : (
-        <PageContainer>
-          <Box my={5}>
-            <EditReleaseNoteForm
-              note={note}
-              onSave={handleSave}
-              onCancel={handleCancel}
-            />
-          </Box>
-        </PageContainer>
-      )}
+      <PageContainer>
+        <Box my={5}>
+          <EditReleaseNoteForm
+            note={note}
+            onSave={handleSave}
+            onCancel={handleCancel}
+          />
+        </Box>
+      </PageContainer>
     </React.Fragment>
   );
 };

--- a/src/components/screen/LandingScreen.jsx
+++ b/src/components/screen/LandingScreen.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import PageContainer from "../shared/PageContainer";
 import Product from "../product/Product";
 import List from "@material-ui/core/List";
-import { ListItem, Container, CircularProgress } from "@material-ui/core";
+import { ListItem, Container } from "@material-ui/core";
 import { useSelector, useDispatch } from "react-redux";
 import { fetchProducts } from "../../actions/productActions";
 

--- a/src/components/screen/ReleasesScreen.jsx
+++ b/src/components/screen/ReleasesScreen.jsx
@@ -27,7 +27,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router";
 import articleParameters, { sortKeys } from "../../articleParameters";
 
-const ReleaseNotesScreen = props => {
+const ReleasesScreen = props => {
   const [anchorEl, setAnchorEl] = React.useState(null)
   let query = useQuery();
   const dispatch = useDispatch();
@@ -169,4 +169,4 @@ const StyledToolbar = styled(Box)`
   }
 `;
 
-export default ReleaseNotesScreen;
+export default ReleasesScreen;

--- a/src/components/shared/AdminExpansionPanel.jsx
+++ b/src/components/shared/AdminExpansionPanel.jsx
@@ -38,7 +38,6 @@ const AdminExpansionPanel = props => {
         }
       : {}
   ];
-
   return (
     <React.Fragment>
       <Modal

--- a/src/components/shared/BottomToolbar.jsx
+++ b/src/components/shared/BottomToolbar.jsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Fade, LinearProgress, AppBar, Toolbar } from "@material-ui/core";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+const BottomToolbar = props => {
+  return (
+    <BottomAppBar>
+      <Fade
+        in={props.loading}
+        style={{
+          transitionDelay: props.loading ? "800ms" : "0ms"
+        }}
+      >
+        <LinearProgress />
+      </Fade>
+      <ToolbarWrapper>
+        <StyledToolbar disableGutters variant="dense">
+          <div>{props.left}</div>
+          <div>{props.right}</div>
+        </StyledToolbar>
+      </ToolbarWrapper>
+    </BottomAppBar>
+  );
+};
+
+export default BottomToolbar;
+
+BottomToolbar.propTypes = {
+  loading: PropTypes.bool,
+  left: PropTypes.arrayOf(PropTypes.element),
+  right: PropTypes.arrayOf(PropTypes.element)
+};
+
+const StyledToolbar = styled(Toolbar)`
+  justify-content: space-between;
+`;
+
+const ToolbarWrapper = styled.div`
+  width: ${props => props.theme.contentWidth};
+  max-width: ${props => props.theme.contentWidth};
+  margin: auto;
+`;
+
+const BottomAppBar = styled(AppBar)`
+  & {
+    background-color: ${props => props.theme.mainColor} !important;
+    position: fixed;
+    top: auto !important;
+    bottom: 0 !important;
+  }
+`;

--- a/src/reducers/combinedReducers.js
+++ b/src/reducers/combinedReducers.js
@@ -1,10 +1,12 @@
 import {combineReducers} from 'redux'
 import {articlesReducer} from './articlesReducer'
 import { productsReducer } from './productsReducer'
+import { releaseNotesReducer } from './releaseNotesReducer'
 
 export default combineReducers({
     //example1: example1Reducer,
     //example2: example2Reducer,
     articles: articlesReducer,
     products: productsReducer,
+    releaseNotes: releaseNotesReducer,
 })

--- a/src/reducers/initialStates.js
+++ b/src/reducers/initialStates.js
@@ -9,3 +9,15 @@ export const articles = {
     items: [],
     error: null
 }
+
+export const releaseNotes = {
+    pending: false,
+    items: [],
+    error: null
+}
+
+export const releaseNote = {
+    pending: false,
+    item: {},
+    error: null
+}

--- a/src/reducers/initialStates.js
+++ b/src/reducers/initialStates.js
@@ -19,5 +19,6 @@ export const releaseNotes = {
 export const releaseNote = {
     pending: false,
     item: {},
-    error: null
+    error: null,
+    updated: null
 }

--- a/src/reducers/releaseNotesReducer.js
+++ b/src/reducers/releaseNotesReducer.js
@@ -54,7 +54,6 @@ function releaseNoteReducer(state, action) {
   switch (action.type) {
     case PUT_RELEASENOTE_PENDING:
     case FETCH_RELEASENOTE_PENDING:
-      console.log("Fuck bitches ge tmoney ey");
       return update(state, {
         pending: { $set: true },
         item: { $merge: { id: parseInt(action.id) } }

--- a/src/reducers/releaseNotesReducer.js
+++ b/src/reducers/releaseNotesReducer.js
@@ -1,0 +1,73 @@
+import {
+  FETCH_RELEASENOTE_PENDING,
+  FETCH_RELEASENOTE_SUCCESS,
+  FETCH_RELEASENOTE_ERROR,
+  PUT_RELEASENOTE_PENDING,
+  PUT_RELEASENOTE_SUCCESS,
+  PUT_RELEASENOTE_ERROR
+} from "../actions/releaseNoteActions";
+import { releaseNotes, releaseNote } from "./initialStates";
+import update from "immutability-helper";
+
+const initialState = releaseNotes;
+// reducer for all release notes
+export function releaseNotesReducer(state = initialState, action) {
+  switch (action.type) {
+    case FETCH_RELEASENOTE_PENDING:
+      return doUpdateItem(state, action);
+    case FETCH_RELEASENOTE_SUCCESS:
+      return doUpdateItem(state, action);
+    case FETCH_RELEASENOTE_ERROR:
+      return doUpdateItem(state, action);
+
+    case PUT_RELEASENOTE_PENDING:
+      return doUpdateItem(state, action);
+    case PUT_RELEASENOTE_SUCCESS:
+      return doUpdateItem(state, action);
+    case PUT_RELEASENOTE_ERROR:
+      return doUpdateItem(state, action);
+
+    default:
+      return state;
+  }
+}
+
+function doUpdateItem(state, action) {
+  const index = state.items.findIndex(r => r.item.id === action.id);
+  console.log(index);
+  if (index === -1) {
+    return update(state, {
+      items: {
+        $push: [releaseNoteReducer(releaseNote, action)]
+      }
+    });
+  }
+  return update(state, {
+    items: {
+      [index]: { $set: releaseNoteReducer(state.items[index], action) }
+    }
+  });
+}
+
+// reducer for a single release note
+function releaseNoteReducer(state = releaseNote, action) {
+  switch (action.type) {
+    case FETCH_RELEASENOTE_PENDING:
+      return update(state, {
+        pending: { $set: true }
+      });
+    case FETCH_RELEASENOTE_SUCCESS:
+      return update(state, {
+        pending: { $set: false },
+        item: { $set: action.payload },
+        error: { $set: null }
+      });
+    case FETCH_RELEASENOTE_ERROR:
+      return update(state, {
+        pending: { $set: false },
+        error: { $set: action.payload }
+      });
+    default:
+      return state;
+  }
+}

--- a/src/reducers/releaseNotesReducer.js
+++ b/src/reducers/releaseNotesReducer.js
@@ -33,8 +33,8 @@ export function releaseNotesReducer(state = initialState, action) {
 }
 
 function doUpdateItem(state, action) {
-  const index = state.items.findIndex(r => r.item.id === action.id);
-  console.log(index);
+  const index = state.items.findIndex(r => r.item.id == action.id);
+  console.log("item with index " + index);
   if (index === -1) {
     return update(state, {
       items: {
@@ -50,11 +50,14 @@ function doUpdateItem(state, action) {
 }
 
 // reducer for a single release note
-function releaseNoteReducer(state = releaseNote, action) {
+function releaseNoteReducer(state, action) {
   switch (action.type) {
+    case PUT_RELEASENOTE_PENDING:
     case FETCH_RELEASENOTE_PENDING:
+      console.log("Fuck bitches ge tmoney ey");
       return update(state, {
-        pending: { $set: true }
+        pending: { $set: true },
+        item: { $merge: { id: parseInt(action.id) } }
       });
     case FETCH_RELEASENOTE_SUCCESS:
       return update(state, {
@@ -62,6 +65,14 @@ function releaseNoteReducer(state = releaseNote, action) {
         item: { $set: action.payload },
         error: { $set: null }
       });
+    case PUT_RELEASENOTE_SUCCESS:
+      return update(state, {
+        pending: { $set: false },
+        item: { $set: action.payload },
+        error: { $set: null },
+        updated: { $set: Date.now() }
+      });
+    case PUT_RELEASENOTE_ERROR:
     case FETCH_RELEASENOTE_ERROR:
       return update(state, {
         pending: { $set: false },

--- a/src/reducers/releaseNotesReducer.test.js
+++ b/src/reducers/releaseNotesReducer.test.js
@@ -1,0 +1,17 @@
+import { releaseNotes, releaseNote } from "./initialStates";
+import { releaseNotesReducer } from "./releaseNotesReducer";
+import {
+  actions,
+  FETCH_RELEASENOTE_SUCCESS
+} from "../actions/releaseNoteActions";
+
+describe("releaseNotes reducer", () => {
+  it("should return the initial state", () => {
+    expect(releaseNotesReducer(undefined, {})).toEqual(releaseNotes);
+  });
+  it("should ", () => {
+    expect(
+      releaseNotesReducer(undefined, actions.fetchReleaseNotePending())
+    ).toHaveProperty("items");
+  });
+});


### PR DESCRIPTION
18 files changed 🆒🆒🆒
**Features**
- Redux logikk for å fetche og putte enkelte release notes 
- Ny screen: AdminReleaseNotesScreen, for å vise alle release notes
- Ny screen: ReleaseNotesEditorScreen, for å vise releaseNote editoren
- Finere UI i EditReleaseNoteForm
- User feedback på lagring av release note
- Populering av editor med data fra serveren 

**Andre ting**
- La inn redirect til login på når du fe en 401 respons. For å gjer ditta måtte e flytte alt av <Route> fra App.js til et eget <Routes> komponent. 
- Renamea "ReleaseNotesScreen" til "ReleasesScreen". Syns de originale navnet krasja med den nye "AdminReleaseNotesScreen", og so e det også meir beskrivande for ka komponentet inneheld.. 