### PR TITLE
Added tests for release get and put.

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -2,7 +2,7 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';
-import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import "@testing-library/jest-dom/extend-expect";
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
 configure({ adapter: new Adapter() });

--- a/src/slices/releaseSlice.js
+++ b/src/slices/releaseSlice.js
@@ -6,7 +6,7 @@ export const releaseSlice = createSlice({
   name: "releases",
   initialState: { pending: false, error: "", items: [] },
   reducers: {
-    getPending(state, action) {
+    getPending(state) {
       state.pending = true;
     },
     getSuccess(state, action) {
@@ -68,4 +68,5 @@ export const updateIsPublic = (id, isPublic) => async dispatch => {
     });
 };
 
+export default releaseSlice.reducer;
 // https://github.com/reduxjs/redux-toolkit/blob/master/docs/usage/usage-guide.md

--- a/src/slices/releaseSlice.test.js
+++ b/src/slices/releaseSlice.test.js
@@ -1,0 +1,202 @@
+import releases, {
+  getPending,
+  getSuccess,
+  getError,
+  putIsPublicPending,
+  putIsPublicSuccess,
+  putIsPublicError
+} from "./releaseSlice";
+
+console.log(releases);
+
+const initialState = {
+  pending: false,
+  error: "",
+  items: [
+    {
+      "0": {
+        id: 100,
+        productVersion: {
+          id: 100,
+          productId: 100,
+          product: null,
+          version: "2.5.4",
+          isPublic: false
+        },
+        title: "Finally Rich",
+        isPublic: false,
+        releaseNotes: []
+      }
+    }
+  ]
+};
+
+const initialStateWithoutItems = {
+  pending: false,
+  error: "",
+  items: []
+};
+
+describe("releases reducer", () => {
+  it("should handle initial state", () => {
+    expect(releases(undefined, {})).toEqual(initialStateWithoutItems);
+  });
+
+  it("should handle putIsPublicSuccess", () => {
+    expect(
+      releases(initialState, {
+        type: getSuccess.type,
+        payload: {
+          id: 100,
+          productVersion: {
+            id: 100,
+            productId: 100,
+            product: null,
+            version: "2.5.4",
+            isPublic: false
+          },
+          title: "Finally Rich",
+          isPublic: true,
+          releaseNotes: []
+        }
+      })
+    ).toEqual({
+      pending: false,
+      error: "",
+      items: {
+        id: 100,
+        productVersion: {
+          id: 100,
+          productId: 100,
+          product: null,
+          version: "2.5.4",
+          isPublic: false
+        },
+        title: "Finally Rich",
+        isPublic: true,
+        releaseNotes: []
+      }
+    });
+  });
+  it("should handle getSuccess", () => {
+    expect(
+      releases(initialStateWithoutItems, {
+        type: getSuccess.type,
+        payload: [
+          {
+            id: 100,
+            productVersion: {
+              id: 100,
+              productId: 100,
+              product: null,
+              version: "2.5.4",
+              isPublic: false
+            },
+            title: "Finally Rich",
+            isPublic: true,
+            releaseNotes: []
+          },
+          {
+            id: 101,
+            productVersion: {
+              id: 101,
+              productId: 100,
+              product: null,
+              version: "3.1.1",
+              isPublic: false
+            },
+            title: "Love Sosa",
+            isPublic: true,
+            releaseNotes: []
+          },
+          {
+            id: 102,
+            productVersion: {
+              id: 102,
+              productId: 101,
+              product: null,
+              version: "5.3",
+              isPublic: false
+            },
+            title: "Chief Keef",
+            isPublic: true,
+            releaseNotes: []
+          },
+          {
+            id: 103,
+            productVersion: {
+              id: 103,
+              productId: 102,
+              product: null,
+              version: "4.2",
+              isPublic: false
+            },
+            title: "2012",
+            isPublic: false,
+            releaseNotes: []
+          }
+        ]
+      })
+    ).toEqual({
+      pending: false,
+      error: "",
+      items: [
+        {
+          id: 100,
+          productVersion: {
+            id: 100,
+            productId: 100,
+            product: null,
+            version: "2.5.4",
+            isPublic: false
+          },
+          title: "Finally Rich",
+          isPublic: true,
+          releaseNotes: []
+        },
+
+        {
+          id: 101,
+          productVersion: {
+            id: 101,
+            productId: 100,
+            product: null,
+            version: "3.1.1",
+            isPublic: false
+          },
+          title: "Love Sosa",
+          isPublic: true,
+          releaseNotes: []
+        },
+
+        {
+          id: 102,
+          productVersion: {
+            id: 102,
+            productId: 101,
+            product: null,
+            version: "5.3",
+            isPublic: false
+          },
+          title: "Chief Keef",
+          isPublic: true,
+          releaseNotes: []
+        },
+
+        {
+          id: 103,
+          productVersion: {
+            id: 103,
+            productId: 102,
+            product: null,
+            version: "4.2",
+            isPublic: false
+          },
+          title: "2012",
+          isPublic: false,
+          releaseNotes: []
+        }
+      ]
+    });
+  });
+});


### PR DESCRIPTION
Added unit-tests for releases slice.

- Tests if releases reducer handles initial state.
- Tests if *putIsPublicSuccess* changes the state of the chosen release.
- Tests if *getSuccess* changes state of items, based on payload items.