### PR TITLE
No longer removes date on exit AB#214

### DIFF
--- a/src/components/releaseEditor/FilterToolbar.jsx
+++ b/src/components/releaseEditor/FilterToolbar.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import { Box } from "@material-ui/core";
 import PopperButton from "../shared/PopperButton";
@@ -7,12 +7,21 @@ import ToolbarBase from "../shared/ToolbarBase";
 import PropTypes from "prop-types";
 
 const FilterToolbar = props => {
+  const [startDate, setStartDate] = useState(null);
+  const [endDate, setEndDate] = useState(new Date());
+
   return (
     <StyledBox my={3} px={2}>
       <ToolbarBase
         right={
-          <PopperButton label="Dato" >
-            <DateRangePicker {...props} />
+          <PopperButton label="Dato">
+            <DateRangePicker
+              startDate={startDate}
+              setStartDate={setStartDate}
+              endDate={endDate}
+              setEndDate={setEndDate}
+              {...props}
+            />
           </PopperButton>
         }
       ></ToolbarBase>

--- a/src/components/shared/DateRangePicker.jsx
+++ b/src/components/shared/DateRangePicker.jsx
@@ -9,9 +9,7 @@ import PropTypes from "prop-types";
 moment.locale("nb");
 
 const DateRangePicker = props => {
-  const [startDate, setStartDate] = useState(null);
-  const [endDate, setEndDate] = useState(new Date());
-  const { onChange } = props;
+  const { onChange, startDate, endDate, setStartDate, setEndDate } = props;
   useMemo(() => {
     onChange({
       startDate: startDate?.toJSON(),


### PR DESCRIPTION
Moved the state up, so that it persists between opening/closeing datepicker.