### PR TITLE
Implement edit releaseNote from release-editor AB#220 AB#223

### DIFF
--- a/src/components/releaseEditor/Column.jsx
+++ b/src/components/releaseEditor/Column.jsx
@@ -19,6 +19,7 @@ const Column = props => {
                 handleRemoveReleaseNote={
                   props.isRelease ? props.handleRemoveReleaseNote : undefined
                 }
+                onSave={props.onSaveReleaseNote}
               />
             ))}
             {provided.placeholder}

--- a/src/components/releaseEditor/ReleaseEditor.jsx
+++ b/src/components/releaseEditor/ReleaseEditor.jsx
@@ -195,7 +195,21 @@ class ReleaseEditor extends Component {
     this.props.onSave(release);
   };
 
-  handleEditReleaseNote = () => {};
+  handleSaveReleaseNote = (releaseNoteId, releaseNote) => {
+    // save editor state locally
+    console.log(releaseNote);
+    const release = {
+      id: this.props.release.id,
+      productVersion: this.props.productVersionsResource.items.find(
+        item => item.id == this.state.selectedProductVersionId
+      ),
+      title: this.state.title,
+      isPublic: this.state.isPublic,
+      releaseNotes: this.state.allItems.release.list
+    };
+    this.props.onSaveEditorState(release);
+    this.props.onSaveReleaseNote(releaseNoteId, releaseNote);
+  };
 
   handleOnChangeProductVersion = event => {
     const newProductVersionId = event.currentTarget.id;
@@ -461,7 +475,7 @@ class ReleaseEditor extends Component {
                   releaseNotes={this.state.allItems.release.list}
                   noteWidth={this.state.noteWidth}
                   handleRemoveReleaseNote={this.handleRemoveReleaseNote}
-                  onSaveReleaseNote={this.props.onSaveReleaseNote}
+                  onSaveReleaseNote={this.handleSaveReleaseNote}
                 />
               </ReleaseContainer>
               <VerticalDivider orientation={"vertical"} />

--- a/src/components/releaseEditor/ReleaseEditor.jsx
+++ b/src/components/releaseEditor/ReleaseEditor.jsx
@@ -196,8 +196,8 @@ class ReleaseEditor extends Component {
   };
 
   handleSaveReleaseNote = (releaseNoteId, releaseNote) => {
-    // save editor state locally
-    console.log(releaseNote);
+    // save editor state locally, then save release note
+
     const release = {
       id: this.props.release.id,
       productVersion: this.props.productVersionsResource.items.find(

--- a/src/components/releaseEditor/ReleaseEditor.jsx
+++ b/src/components/releaseEditor/ReleaseEditor.jsx
@@ -195,6 +195,8 @@ class ReleaseEditor extends Component {
     this.props.onSave(release);
   };
 
+  handleEditReleaseNote = () => {};
+
   handleOnChangeProductVersion = event => {
     const newProductVersionId = event.currentTarget.id;
     const newProductVersionLabel = event.target.value;
@@ -366,7 +368,7 @@ class ReleaseEditor extends Component {
               label="Publisert"
             />,
             <SaveButton
-              key="cancelBtn"
+              key="saveBtn"
               disabled={this.state.submitDisabled}
               variant="contained"
               onClick={this.handleSave}
@@ -459,6 +461,7 @@ class ReleaseEditor extends Component {
                   releaseNotes={this.state.allItems.release.list}
                   noteWidth={this.state.noteWidth}
                   handleRemoveReleaseNote={this.handleRemoveReleaseNote}
+                  onSaveReleaseNote={this.props.onSaveReleaseNote}
                 />
               </ReleaseContainer>
               <VerticalDivider orientation={"vertical"} />
@@ -495,7 +498,9 @@ ReleaseEditor.propTypes = {
 
   onCancel: PropTypes.func,
   onSave: PropTypes.func,
-  onFilter: PropTypes.func
+  onFilter: PropTypes.func,
+
+  onSaveReleaseNote: PropTypes.func
 };
 
 const ErrorMsgContainer = styled.div`

--- a/src/components/releaseEditor/ReleaseNote.jsx
+++ b/src/components/releaseEditor/ReleaseNote.jsx
@@ -4,6 +4,7 @@ import { Paper, Divider, IconButton, Box } from "@material-ui/core";
 import styled from "styled-components";
 import { Delete } from "@material-ui/icons";
 import ReleaseNotePreview from "../shared/ReleaseNotePreview";
+import ReleaseNoteEditorModal from "../releaseNoteEditor/ReleaseNoteEditorModal";
 
 const ReleaseNote = props => {
   return (
@@ -22,6 +23,11 @@ const ReleaseNote = props => {
             <Box>
               {props.isRelease && (
                 <React.Fragment>
+                  <ReleaseNoteEditorModal
+                    note={props.releaseNote}
+                    onSave={props.onSave}
+                  />
+
                   <StyledIconButton
                     onClick={() => props.handleRemoveReleaseNote(props.index)}
                   >

--- a/src/components/releaseEditor/ReleaseNote.jsx
+++ b/src/components/releaseEditor/ReleaseNote.jsx
@@ -23,10 +23,12 @@ const ReleaseNote = props => {
             <Box>
               {props.isRelease && (
                 <React.Fragment>
-                  <ReleaseNoteEditorModal
-                    note={props.releaseNote}
-                    onSave={props.onSave}
-                  />
+                  <FlexEnd>
+                    <ReleaseNoteEditorModal
+                      note={props.releaseNote}
+                      onSave={props.onSave}
+                    />
+                  </FlexEnd>
 
                   <StyledIconButton
                     onClick={() => props.handleRemoveReleaseNote(props.index)}
@@ -51,6 +53,11 @@ const StyledIconButton = styled(IconButton)`
     margin-left: auto;
     display: flex-end;
   }
+`;
+
+const FlexEnd = styled.div`
+  margin-left: auto;
+  display: flex-end;
 `;
 
 const StyledContainer = styled(Paper)`

--- a/src/components/releaseNoteEditor/ReleaseNoteEditorModal.jsx
+++ b/src/components/releaseNoteEditor/ReleaseNoteEditorModal.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { IconButton, Modal, Box, AppBar, Toolbar } from "@material-ui/core";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import { Edit } from "@material-ui/icons";
+import PageContainer from "../shared/PageContainer";
+import ReleaseNoteEditor from "./ReleaseNoteEditor";
+const ReleaseNoteEditorModal = props => {
+  const [open, setOpen] = React.useState(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    if (props.onCancel) props.onCancel();
+    setOpen(false);
+  };
+
+  const handleSave = objectToSave => {
+    props.onSave(props.note.id, objectToSave);
+    handleClose();
+  };
+
+  return (
+    <React.Fragment>
+      <IconButton onClick={handleOpen}>
+        <Edit />
+      </IconButton>
+      <Modal open={open} onClose={handleClose} style={{ overflow: "scroll" }}>
+        <ModalContainer>
+          <PageContainer>
+            <Background>
+              <AppBar position="relative">
+                <Toolbar variant="dense">Rediger release note</Toolbar>
+              </AppBar>
+              <Box px={3} py={3}>
+                <ReleaseNoteEditor
+                  onSave={handleSave}
+                  onCancel={handleClose}
+                  note={props.note}
+                />
+              </Box>
+            </Background>
+          </PageContainer>
+        </ModalContainer>
+      </Modal>
+    </React.Fragment>
+  );
+};
+
+export default ReleaseNoteEditorModal;
+
+ReleaseNoteEditorModal.propTypes = {
+  icon: PropTypes.element,
+  modalContent: PropTypes.element
+};
+
+const Background = styled.div`
+  background-color: white;
+  border-radius: 12px;
+`;
+
+const ModalContainer = styled.div`
+  && {
+    padding: 3rem 0;
+  }
+`;

--- a/src/components/releaseNoteEditor/ReleaseNoteEditorModal.jsx
+++ b/src/components/releaseNoteEditor/ReleaseNoteEditorModal.jsx
@@ -52,8 +52,9 @@ const ReleaseNoteEditorModal = props => {
 export default ReleaseNoteEditorModal;
 
 ReleaseNoteEditorModal.propTypes = {
-  icon: PropTypes.element,
-  modalContent: PropTypes.element
+  note: PropTypes.object,
+  onSave: PropTypes.func,
+  onCancel: PropTypes.func
 };
 
 const Background = styled.div`

--- a/src/components/screen/ReleaseEditorScreen.jsx
+++ b/src/components/screen/ReleaseEditorScreen.jsx
@@ -15,7 +15,10 @@ import {
   getSuccesMessage
 } from "../../slices/releaseSlice";
 import { loadingSelector } from "../../slices/loadingSlice";
-import { fetchReleaseNotes } from "../../slices/releaseNoteSlice";
+import {
+  fetchReleaseNotes,
+  putReleaseNote
+} from "../../slices/releaseNoteSlice";
 import {
   initReleaseEditorReleaseNotes,
   findReleaseById
@@ -49,6 +52,10 @@ const ReleaseEditorScreen = props => {
     }
   };
 
+  const handleSaveReleaseNote = (id, objectToSave) => {
+    dispatch(putReleaseNote(id, objectToSave));
+  };
+
   const handleFilter = query => {
     dispatch(fetchReleaseNotes(query));
   };
@@ -78,6 +85,7 @@ const ReleaseEditorScreen = props => {
         onCancel={handleCancel}
         onSave={handleSave}
         onFilter={handleFilter}
+        onSaveReleaseNote={handleSaveReleaseNote}
         loading={loading}
       />
       <ResponseSnackbar error={error} success={success} />

--- a/src/components/screen/ReleaseEditorScreen.jsx
+++ b/src/components/screen/ReleaseEditorScreen.jsx
@@ -12,7 +12,8 @@ import {
   fetchReleaseById,
   putReleaseById,
   postRelease,
-  getSuccesMessage
+  getSuccesMessage,
+  putByIdSuccess
 } from "../../slices/releaseSlice";
 import { loadingSelector } from "../../slices/loadingSlice";
 import {
@@ -45,6 +46,7 @@ const ReleaseEditorScreen = props => {
   const handleSave = objectToSave => {
     // if screen has an id, a release is being updated
     // otherwise, a release is being created
+    console.log(objectToSave);
     if (id) {
       dispatch(putReleaseById(id, objectToSave));
     } else {
@@ -54,6 +56,10 @@ const ReleaseEditorScreen = props => {
 
   const handleSaveReleaseNote = (id, objectToSave) => {
     dispatch(putReleaseNote(id, objectToSave));
+  };
+
+  const handleSaveEditorState = release => {
+    dispatch(putByIdSuccess({ data: release, id }));
   };
 
   const handleFilter = query => {
@@ -85,6 +91,7 @@ const ReleaseEditorScreen = props => {
         onCancel={handleCancel}
         onSave={handleSave}
         onFilter={handleFilter}
+        onSaveEditorState={handleSaveEditorState}
         onSaveReleaseNote={handleSaveReleaseNote}
         loading={loading}
       />

--- a/src/slices/releaseSlice.js
+++ b/src/slices/releaseSlice.js
@@ -1,6 +1,7 @@
 import { createReducer, createAction } from "@reduxjs/toolkit";
 import Axios from "axios";
 import { updateInArray, deleteInArray } from "../utils/stateUtil";
+import { saveSuccess as saveReleaseNoteSuccess } from "./releaseNoteSlice";
 
 // ACTIONS
 export const name = "release/";
@@ -42,6 +43,18 @@ export const releaseReducer = createReducer(initialState, {
     updateInArray(state, action);
     state.successMsg = action.payload.response;
   },
+  [saveReleaseNoteSuccess]: (state, action) => {
+    // release note updated, update affected releases
+    state.items.forEach(release => {
+      const index = release.releaseNotes.findIndex(
+        obj => obj.id == action.payload.id
+      );
+      if (index !== -1) {
+        release.releaseNotes[index] = action.payload.data;
+      }
+    });
+  },
+
   [deleteSuccess]: (state, action) => {
     deleteInArray(state, action);
   },
@@ -110,7 +123,7 @@ export function deleteRelease(id) {
     dispatch(deletePending());
     return Axios.delete("/releases/" + id)
       .then(response => {
-        dispatch(deleteSuccess({id}));
+        dispatch(deleteSuccess({ id }));
       })
       .catch(error => {
         dispatch(deleteError(error));


### PR DESCRIPTION
Lagt inn knapp med modal for å redigere en release note. Måtte gjer nokre få ting for å få editoren til å oppføre se: 

- Oppdatere releases i staten når en release note he blitt lagra, slik at den oppdaterte release noten vise i editoren

- Lagre staten til en release lokalt når en release note blir lagra. Forhindra at alle endringe i editoren blir mista når en release note blir oppdatert.

![bilde](https://user-images.githubusercontent.com/35314375/77645902-d7baa400-6f63-11ea-9b90-b598a7fc1d4f.png)

![bilde](https://user-images.githubusercontent.com/35314375/77640475-be612a00-6f5a-11ea-8689-165d132bd765.png)
