### PR TITLE
Fix tabpanel bugs AB#253 AB#256

### DIFF
--- a/src/components/Routes.jsx
+++ b/src/components/Routes.jsx
@@ -27,17 +27,20 @@ const Routes = () => {
     }
   );
   return (
-    <React.Fragment>
+    <>
       <Route path="/" exact component={LandingScreen} />
       <Route path="/releases" exact component={ReleasesScreen} />
-      <Route path="/admin/" exact component={AdminScreen} />
+      <Route path="/admin/">
+        <AdminScreen />
+      </Route>
+
       <Route
-        path="/admin/releasenotes/edit/:id"
+        path="/releasenotes/edit/:id"
         exact
         render={props => <ReleaseNoteEditorScreen {...props} />}
       />
       <Route
-        path="/admin/releasenotes/create"
+        path="/releasenotes/create"
         exact
         component={ReleaseNoteEditorScreen}
       />
@@ -47,17 +50,9 @@ const Routes = () => {
         render={props => <ReleaseScreen {...props} />}
       />
       <Route path="/login/" exact component={LoginScreen} />
-      <Route
-        path="/admin/releases/create"
-        exact
-        component={ReleaseEditorScreen}
-      />
-      <Route
-        path="/admin/releases/edit/:id"
-        exact
-        component={ReleaseEditorScreen}
-      />
-    </React.Fragment>
+      <Route path="/releases/create" exact component={ReleaseEditorScreen} />
+      <Route path="/releases/edit/:id" exact component={ReleaseEditorScreen} />
+    </>
   );
 };
 

--- a/src/components/screen/AdminAzureView.jsx
+++ b/src/components/screen/AdminAzureView.jsx
@@ -4,7 +4,7 @@ import { createSelector } from "@reduxjs/toolkit";
 import { createData } from "../shared/AdminTableRow";
 import { importRelease } from "../../slices/azureSlice";
 import AzureDevOpsView from "../adminpanel/AzureDevOpsView";
-import { azureApiSelector, fetchAzureInfo } from "../../slices/authSlice";
+import { azureApiSelector } from "../../slices/authSlice";
 import { useLocation } from "react-router";
 
 const AdminAzureView = () => {
@@ -46,10 +46,6 @@ const AdminAzureView = () => {
       )
     );
   };
-
-  useEffect(() => {
-    dispatch(fetchAzureInfo());
-  }, [dispatch]);
 
   return (
     <AzureDevOpsView

--- a/src/components/screen/AdminAzureView.jsx
+++ b/src/components/screen/AdminAzureView.jsx
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { createSelector } from "@reduxjs/toolkit";
+import { createData } from "../shared/AdminTableRow";
+import { importRelease } from "../../slices/azureSlice";
+import AzureDevOpsView from "../adminpanel/AzureDevOpsView";
+import { azureApiSelector, fetchAzureInfo } from "../../slices/authSlice";
+import { useLocation } from "react-router";
+
+const AdminAzureView = () => {
+  const location = useLocation();
+  console.log(location);
+  const dispatch = useDispatch();
+  const azureProjects = useSelector(state => state.azure.projects);
+  const azureReleases = useSelector(azureReleasesSelector);
+
+  const [selectedProject, setSelectedProject] = useState("");
+  const [selectedProductVersion, setSelectedProductVersion] = useState("");
+  const azureProps = useSelector(azureApiSelector);
+
+  // Fetches all releases based on selected Project
+  useEffect(() => {
+    const params = {
+      organization: azureProps.organization,
+      project: selectedProject,
+      authToken: azureProps.authToken
+    };
+    //if (params.project !== "") dispatch(fetchAzureReleases(params));
+  }, [dispatch, azureProps, selectedProject]);
+
+  const handleSelectedProject = event => {
+    setSelectedProject(event.target.value);
+  };
+  const handleSelectedProductVersion = event => {
+    setSelectedProductVersion(event.target.value);
+  };
+
+  const handleImport = (id, title) => {
+    dispatch(
+      importRelease(
+        selectedProductVersion.id,
+        selectedProject,
+        azureProps,
+        id,
+        title
+      )
+    );
+  };
+
+  useEffect(() => {
+    dispatch(fetchAzureInfo());
+  }, [dispatch]);
+
+  return (
+    <AzureDevOpsView
+      azureReleases={azureReleases}
+      azureProjects={azureProjects}
+      azureProps={azureProps}
+      selectedProject={selectedProject}
+      selectedProductVersion={selectedProductVersion}
+      handleSelectedProject={handleSelectedProject}
+      handleSelectedProductVersion={handleSelectedProductVersion}
+      handleImport={handleImport}
+    />
+  );
+};
+
+export default AdminAzureView;
+
+// selectors
+const azureReleasesSelector = createSelector(
+  state => state.azure.releases,
+  releases => releases.map(r => createData(r, r.name, r.id))
+);

--- a/src/components/screen/AdminAzureView.jsx
+++ b/src/components/screen/AdminAzureView.jsx
@@ -2,21 +2,20 @@ import React, { useState, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { createSelector } from "@reduxjs/toolkit";
 import { createData } from "../shared/AdminTableRow";
-import { importRelease } from "../../slices/azureSlice";
+import { importRelease, fetchProjects } from "../../slices/azureSlice";
 import AzureDevOpsView from "../adminpanel/AzureDevOpsView";
 import { azureApiSelector } from "../../slices/authSlice";
-import { useLocation } from "react-router";
+import { fetchReleases as fetchAzureReleases } from "../../slices/azureSlice";
 
 const AdminAzureView = () => {
-  const location = useLocation();
-  console.log(location);
   const dispatch = useDispatch();
-  const azureProjects = useSelector(state => state.azure.projects);
-  const azureReleases = useSelector(azureReleasesSelector);
-
   const [selectedProject, setSelectedProject] = useState("");
   const [selectedProductVersion, setSelectedProductVersion] = useState("");
+
   const azureProps = useSelector(azureApiSelector);
+  useEffect(() => {
+    dispatch(fetchProjects(azureProps));
+  }, [dispatch, azureProps]);
 
   // Fetches all releases based on selected Project
   useEffect(() => {
@@ -25,12 +24,16 @@ const AdminAzureView = () => {
       project: selectedProject,
       authToken: azureProps.authToken
     };
-    //if (params.project !== "") dispatch(fetchAzureReleases(params));
+    if (params.project !== "") dispatch(fetchAzureReleases(params));
   }, [dispatch, azureProps, selectedProject]);
+
+  const azureProjects = useSelector(state => state.azure.projects);
+  const azureReleases = useSelector(azureReleasesSelector);
 
   const handleSelectedProject = event => {
     setSelectedProject(event.target.value);
   };
+
   const handleSelectedProductVersion = event => {
     setSelectedProductVersion(event.target.value);
   };

--- a/src/components/screen/AdminHomeView.jsx
+++ b/src/components/screen/AdminHomeView.jsx
@@ -26,6 +26,7 @@ import { fetchUsers } from "../../slices/userSlice";
 
 const AdminHomeView = props => {
   const dispatch = useDispatch();
+
   useEffect(() => {
     dispatch(fetchProducts());
   }, [dispatch]);

--- a/src/components/screen/AdminHomeView.jsx
+++ b/src/components/screen/AdminHomeView.jsx
@@ -1,0 +1,115 @@
+import { useSelector, useDispatch } from "react-redux";
+import AdminExpansionPanelRoute from "../shared/AdminExpansionPanelRoute";
+import AdminExpansionPanelModal from "../shared/AdminExpansionPanelModal";
+
+import React, { useEffect } from "react";
+import { DesktopWindows, PermIdentity, Description } from "@material-ui/icons";
+import {
+  putReleaseById,
+  deleteRelease,
+  fetchReleases
+} from "../../slices/releaseSlice";
+import {
+  putReleaseNote,
+  deleteReleaseNote,
+  fetchReleaseNotes
+} from "../../slices/releaseNoteSlice";
+import { fetchProducts } from "../../slices/productsSlice";
+import { createSelector } from "@reduxjs/toolkit";
+import { createData } from "../shared/AdminTableRow";
+
+import EditProductForm from "../adminpanel/EditProductForm";
+import AddProductForm from "../adminpanel/AddProductForm";
+import AddUserForm from "../adminpanel/AddUserForm";
+import ChangePasswordForm from "../adminpanel/ChangePasswordForm";
+import { fetchUsers } from "../../slices/userSlice";
+
+const AdminHomeView = props => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(fetchProducts());
+  }, [dispatch]);
+
+  useEffect(() => {
+    dispatch(fetchReleases());
+  }, [dispatch]);
+
+  useEffect(() => {
+    dispatch(fetchReleaseNotes());
+  }, [dispatch]);
+
+  useEffect(() => {
+    dispatch(fetchUsers());
+  }, [dispatch]);
+
+  const releaseTitles = useSelector(releaseTitlesSelector);
+  const productTitles = useSelector(productTitlesSelector);
+  const userRows = useSelector(userRowsSelector);
+  const releaseNoteRows = useSelector(releaseNoteRowsSelector);
+
+  return (
+    <>
+      <AdminExpansionPanelModal
+        label="Produkter"
+        icon={<DesktopWindows />}
+        rows={productTitles}
+        createContentComponent={<AddProductForm />}
+        editContentComponent={<EditProductForm />}
+      />
+      <AdminExpansionPanelModal
+        label="Brukere"
+        icon={<PermIdentity />}
+        rows={userRows}
+        createContentComponent={<AddUserForm />}
+        editContentComponent={<ChangePasswordForm />}
+      />
+      <AdminExpansionPanelRoute
+        label="Releases"
+        icon={<Description />}
+        rows={releaseTitles}
+        createContentRoute="/releases/create"
+        editContentRoute="/releases/edit/:id"
+        onUpdate={putReleaseById}
+        onDelete={deleteRelease}
+      />
+      <AdminExpansionPanelRoute
+        label="Release notes"
+        icon={<Description />}
+        rows={releaseNoteRows}
+        createContentRoute="/releasenotes/create"
+        editContentRoute="/releasenotes/edit/:id"
+        onUpdate={putReleaseNote}
+        onDelete={deleteReleaseNote}
+      />
+    </>
+  );
+};
+export default AdminHomeView;
+
+const releaseTitlesSelector = createSelector(
+  state => state.releases.items,
+  items => items.map(r => createData(r, r.title, r.id, r.isPublic))
+);
+
+const productTitlesSelector = createSelector(
+  state => state.products.items,
+  items => items.map(p => createData(p, p.name, p.id))
+);
+
+const userRowsSelector = createSelector(
+  state => state.users.items,
+  items => items.map(u => createData(u, u.email, u.id))
+);
+
+const releaseNoteRowsSelector = createSelector(
+  state => state.releaseNotes.items,
+  items =>
+    items.map(r => {
+      return createData(
+        r,
+        r.title === "" ? "Release note #" + r.id : r.title,
+        r.id,
+        r.isPublic
+      );
+    })
+);

--- a/src/components/screen/AdminScreen.jsx
+++ b/src/components/screen/AdminScreen.jsx
@@ -1,128 +1,19 @@
 import React, { useEffect } from "react";
-import { Container, Tabs, Tab, Typography, Divider } from "@material-ui/core";
-import { PermIdentity, DesktopWindows, Description } from "@material-ui/icons";
+import { Tabs, Tab, Divider } from "@material-ui/core";
 import PageContainer from "../shared/PageContainer";
 import Ingress from "../shared/Ingress";
 import ScreenTitle from "../shared/ScreenTitle";
-import AddUserForm from "../adminpanel/AddUserForm";
-import AddProductForm from "../adminpanel/AddProductForm";
-import ChangePasswordForm from "../adminpanel/ChangePasswordForm";
-import { useSelector, useDispatch } from "react-redux";
-import AdminExpansionPanelModal from "../shared/AdminExpansionPanelModal";
-import AdminExpansionPanelRoute from "../shared/AdminExpansionPanelRoute";
-import {
-  fetchReleases,
-  putReleaseById,
-  deleteRelease
-} from "../../slices/releaseSlice";
-import { fetchUsers } from "../../slices/userSlice";
-import {
-  fetchReleaseNotes,
-  putReleaseNote,
-  deleteReleaseNote
-} from "../../slices/releaseNoteSlice";
-import {
-  fetchReleases as fetchAzureReleases,
-  importRelease
-} from "../../slices/azureSlice";
-import { useState } from "react";
+import { Link, useLocation, Switch, Route, Redirect } from "react-router-dom";
+import AdminHomeView from "./AdminHomeView";
+import AdminAzureView from "./AdminAzureView";
 import styled from "styled-components";
-import { fetchProjects } from "../../slices/azureSlice";
-import { azureApiSelector } from "../../slices/authSlice";
-import AzureDevOpsView from "../adminpanel/AzureDevOpsView";
-import { fetchProducts } from "../../slices/productsSlice";
-import { createSelector } from "@reduxjs/toolkit";
-import EditProductForm from "../adminpanel/EditProductForm";
-import { createData } from "../shared/AdminTableRow";
 
 const AdminScreen = () => {
-  const dispatch = useDispatch();
-  const [value, setValue] = useState(0);
-  const [selectedProject, setSelectedProject] = useState("");
-  const [selectedProductVersion, setSelectedProductVersion] = useState("");
+  const location = useLocation();
 
   useEffect(() => {
-    dispatch(fetchProducts());
-  }, [dispatch]);
-
-  useEffect(() => {
-    dispatch(fetchReleases());
-  }, [dispatch]);
-
-  useEffect(() => {
-    dispatch(fetchReleaseNotes());
-  }, [dispatch]);
-
-  const azureProps = useSelector(azureApiSelector);
-  useEffect(() => {
-    dispatch(fetchProjects(azureProps));
-  }, [dispatch, azureProps]);
-
-  useEffect(() => dispatch(fetchUsers()), [dispatch]);
-
-  // Fetches all releases based on selected Project
-  useEffect(() => {
-    const params = {
-      organization: azureProps.organization,
-      project: selectedProject,
-      authToken: azureProps.authToken
-    };
-    if (params.project !== "") dispatch(fetchAzureReleases(params));
-  }, [dispatch, azureProps, selectedProject]);
-
-  const azureProjects = useSelector(state => state.azure.projects);
-  const releaseTitles = useSelector(releaseTitlesSelector);
-  const azureReleases = useSelector(azureReleasesSelector);
-  const productTitles = useSelector(productTitlesSelector);
-  const userRows = useSelector(userRowsSelector);
-  const releaseNoteRows = useSelector(releaseNoteRowsSelector);
-
-  const handleSelectedProject = event => {
-    setSelectedProject(event.target.value);
-  };
-
-  const handleSelectedProductVersion = event => {
-    setSelectedProductVersion(event.target.value);
-  };
-
-  const handleImport = (id, title) => {
-    dispatch(
-      importRelease(
-        selectedProductVersion.id,
-        selectedProject,
-        azureProps,
-        id,
-        title
-      )
-    );
-  };
-
-  const handleChange = (event, newValue) => {
-    setValue(newValue);
-  };
-
-  const tabProps = index => {
-    return {
-      id: `simple-tab-${index}`,
-      "aria-controls": `simple-tabpanel-${index}`
-    };
-  };
-
-  const TabPanel = props => {
-    const { children, value, index, ...other } = props;
-
-    return (
-      <Typography
-        component="div"
-        role="tabpanel"
-        hidden={value !== index}
-        id={`simple-tabpanel-${index}`}
-        {...other}
-      >
-        {value === index && <Container>{children}</Container>}
-      </Typography>
-    );
-  };
+    console.log(location);
+  }, [location]);
 
   return (
     <PageContainer>
@@ -133,58 +24,36 @@ const AdminScreen = () => {
 
       <TurboDivider />
       <StyledAppBar color="transparent" position="static">
-        <Tabs value={value} onChange={handleChange}>
-          <Tab label="Release Notes System" {...tabProps(0)} />
-          <Tab label="Azure DevOps" {...tabProps(1)} />
+        <Tabs
+          value={location.pathname}
+          indicatorColor="primary"
+          textColor="primary"
+        >
+          <Tab
+            component={Link}
+            label="Release Note System"
+            to="/admin/home"
+            value="/admin/home"
+          />
+          <Tab
+            component={Link}
+            label="Azure DevOps"
+            to="/admin/azure"
+            value="/admin/azure"
+          />
         </Tabs>
       </StyledAppBar>
-
-      <TabPanel value={value} index={0}>
-        <AdminExpansionPanelModal
-          label="Produkter"
-          icon={<DesktopWindows />}
-          rows={productTitles}
-          createContentComponent={<AddProductForm />}
-          editContentComponent={<EditProductForm />}
-        />
-        <AdminExpansionPanelModal
-          label="Brukere"
-          icon={<PermIdentity />}
-          rows={userRows}
-          createContentComponent={<AddUserForm />}
-          editContentComponent={<ChangePasswordForm />}
-        />
-        <AdminExpansionPanelRoute
-          label="Releases"
-          icon={<Description />}
-          rows={releaseTitles}
-          createContentRoute="/admin/releases/create"
-          editContentRoute="/admin/releases/edit/:id"
-          onUpdate={putReleaseById}
-          onDelete={deleteRelease}
-        />
-        <AdminExpansionPanelRoute
-          label="Release notes"
-          icon={<Description />}
-          rows={releaseNoteRows}
-          createContentRoute="/admin/releasenotes/create"
-          editContentRoute="/admin/releasenotes/edit/:id"
-          onUpdate={putReleaseNote}
-          onDelete={deleteReleaseNote}
-        />
-      </TabPanel>
-      <TabPanel value={value} index={1}>
-        <AzureDevOpsView
-          azureReleases={azureReleases}
-          azureProjects={azureProjects}
-          azureProps={azureProps}
-          selectedProject={selectedProject}
-          selectedProductVersion={selectedProductVersion}
-          handleSelectedProject={handleSelectedProject}
-          handleSelectedProductVersion={handleSelectedProductVersion}
-          handleImport={handleImport}
-        />
-      </TabPanel>
+      <Switch>
+        <Route exact path="/admin/">
+          <Redirect push to="/admin/home" />
+        </Route>
+        <Route path="/admin/home">
+          <AdminHomeView />
+        </Route>
+        <Route path="/admin/azure">
+          <AdminAzureView />
+        </Route>
+      </Switch>
     </PageContainer>
   );
 };
@@ -207,37 +76,3 @@ const StyledAppBar = styled.div`
     background-color: white;
   }
 `;
-
-// selectors
-const releaseTitlesSelector = createSelector(
-  state => state.releases.items,
-  items => items.map(r => createData(r, r.title, r.id, r.isPublic))
-);
-
-const azureReleasesSelector = createSelector(
-  state => state.azure.releases,
-  releases => releases.map(r => createData(r, r.name, r.id))
-);
-
-const productTitlesSelector = createSelector(
-  state => state.products.items,
-  items => items.map(p => createData(p, p.name, p.id))
-);
-
-const userRowsSelector = createSelector(
-  state => state.users.items,
-  items => items.map(u => createData(u, u.email, u.id))
-);
-
-const releaseNoteRowsSelector = createSelector(
-  state => state.releaseNotes.items,
-  items =>
-    items.map(r => {
-      return createData(
-        r,
-        r.title === "" ? "Release note #" + r.id : r.title,
-        r.id,
-        r.isPublic
-      );
-    })
-);

--- a/src/components/screen/AdminScreen.jsx
+++ b/src/components/screen/AdminScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { Tabs, Tab, Divider } from "@material-ui/core";
 import PageContainer from "../shared/PageContainer";
 import Ingress from "../shared/Ingress";

--- a/src/components/screen/AdminScreen.jsx
+++ b/src/components/screen/AdminScreen.jsx
@@ -11,10 +11,6 @@ import styled from "styled-components";
 const AdminScreen = () => {
   const location = useLocation();
 
-  useEffect(() => {
-    console.log(location);
-  }, [location]);
-
   return (
     <PageContainer>
       <ScreenTitle>ADMINPANEL</ScreenTitle>

--- a/src/components/shared/AdminExpansionPanelRoute.jsx
+++ b/src/components/shared/AdminExpansionPanelRoute.jsx
@@ -15,21 +15,18 @@ const AdminExpansionPanelRoute = props => {
     ...baseProps
   } = props;
   const handleAction = (action, rowData) => {
-    const { id, isPublic } = rowData;
-    console.log(rowData);
     switch (action) {
       case actions.CREATE:
         history.push(props.createContentRoute);
         break;
-
       case actions.EDIT:
-        history.push(props.editContentRoute.replace(":id", id));
+        history.push(props.editContentRoute.replace(":id", rowData.id));
         break;
       case actions.UPDATE:
-        dispatch(props.onUpdate(id, { isPublic }));
+        dispatch(props.onUpdate(rowData.id, { isPublic: rowData.isPublic }));
         break;
       case actions.DELETE:
-        dispatch(props.onDelete(id));
+        dispatch(props.onDelete(rowData.id));
         break;
 
       default:

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -5,21 +5,31 @@
 import "@testing-library/jest-dom/extend-expect";
 import React from "react";
 import { Provider } from "react-redux";
-import { Router, Route } from "react-router";
+import { Router, Route } from "react-router-dom";
 import { store } from "./setupStore";
 import { createMemoryHistory } from "history";
 import { render } from "@testing-library/react";
-const AllTheProviders = ( 
+const AllTheProviders = (
   { children },
   {
-    route = "/",
+    route = "/test-route",
     history = createMemoryHistory({ initialEntries: [route] })
   } = {}
 ) => {
+  if (!route) throw new Error("Uninstansiated route");
+  const mockRoute = route;
+  jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"), // use actual for all non-hook parts
+    useLocation: () => ({ pathname: mockRoute })
+  }));
   return (
     <Provider store={store}>
       <Router history={history}>
-        <Route exact path="/" component={React.Children.only(children).type} />
+        <Route
+          exact
+          path={mockRoute}
+          component={React.Children.only(children).type}
+        />
       </Router>
     </Provider>
   );


### PR DESCRIPTION
OK..........

Måten content i tabs blei rendra på gjorde rare ting, og destruerte komponenta og skapte bugs. He derfor gjort det sånn at det brukast react-router for å rendre tabs. Kan med glede melde at begge bugsa ([AB#253](https://dev.azure.com/ReleaseNoteSystem/399f705f-cd58-45f2-becb-f890cb50f774/_workitems/edit/253) [AB#256](https://dev.azure.com/ReleaseNoteSystem/399f705f-cd58-45f2-becb-f890cb50f774/_workitems/edit/256)) e fiksa, og tater-leiren kan fortsette å synge sine glade vise

He derfor flytta innholdet til kvar tab til si ega fil, men he ellers ikkje endra på dei. ([AdminHomeView](https://github.com/TeamNatron/ReleaseNotes-WebApp/compare/develop...kill-tater?expand=1#diff-c009a46ec883ef698668fe10b00e343f) , [AdminAzureView](https://github.com/TeamNatron/ReleaseNotes-WebApp/compare/develop...kill-tater?expand=1#diff-c009a46ec883ef698668fe10b00e343f) )

alt content i [AdminScreen](https://github.com/TeamNatron/ReleaseNotes-WebApp/blob/93b3f456ff4646c70339de078112f4b65d947fc0/src/components/screen/AdminScreen.jsx) e derfor også bytta ut med nokre routes

Måtte også endre på navnet til routesa til editorane, ellers so ville dei rendre over AdminScreen