### PR TITLE
Associated Releases are shown in deletion of Release Note AB#269

### DIFF
--- a/src/components/shared/AdminTableRow.jsx
+++ b/src/components/shared/AdminTableRow.jsx
@@ -4,19 +4,19 @@ import { TableCell, TableRow, IconButton, Switch } from "@material-ui/core";
 import { Edit, Add } from "@material-ui/icons";
 import DeleteDialogButton from "./DeleteDialogButton";
 import { actions } from "./AdminExpansionPanelBase";
-const AdminTableRow = props => {
+const AdminTableRow = (props) => {
   const { row, columns } = props;
 
   return (
     <TableRow hover role="checkbox" tabIndex={-1} key={row.id}>
-      {columns.map(column => {
+      {columns.map((column) => {
         if (column.id === "avatar") {
           return (
             <StyledTableCell key={column.id}>
               {props.icon ? (
                 React.cloneElement(props.icon, {
                   color: "disabled",
-                  fontSize: "small"
+                  fontSize: "small",
                 })
               ) : (
                 <React.Fragment />
@@ -35,7 +35,7 @@ const AdminTableRow = props => {
                   return props.onAction(actions.UPDATE, { ...row });
                 }}
                 inputProps={{
-                  "aria-label": "primary checkbox"
+                  "aria-label": "primary checkbox",
                 }}
               />
             </StyledTableCell>
@@ -46,6 +46,7 @@ const AdminTableRow = props => {
               <StyledTableCell key={column.id}>
                 <DeleteDialogButton
                   onConfirm={() => props.onAction(actions.DELETE, { ...row })}
+                  id={row.id}
                   entityName={row.name}
                 />
               </StyledTableCell>

--- a/src/components/shared/DeleteDialogButton.jsx
+++ b/src/components/shared/DeleteDialogButton.jsx
@@ -8,11 +8,23 @@ import DialogTitle from "@material-ui/core/DialogTitle";
 import PropTypes from "prop-types";
 import { IconButton } from "@material-ui/core";
 import { Delete } from "@material-ui/icons";
+import { getReleaseNoteWithReleases } from "../../slices/releaseNoteSlice";
+import { useState } from "react";
+import styled from "styled-components";
 
 export default function DeleteDialogButton(props) {
   const [open, setOpen] = React.useState(false);
+  const [releases, setReleases] = useState([]);
+
+  const fetchData = async () => {
+    var releaseNote = await getReleaseNoteWithReleases(props.id);
+    console.log(releaseNote);
+    setReleases(releaseNote.releases);
+  };
 
   const handleClickOpen = () => {
+    console.log(props);
+    fetchData();
     setOpen(true);
   };
 
@@ -44,6 +56,18 @@ export default function DeleteDialogButton(props) {
             Er du sikker på du vil slette denne entiteten? Den vil bli fjernet
             fra systemet for all evighet.
           </DialogContentText>
+          {releases ? (
+            <DialogContentText id="alert-dialog-description">
+              {"Denne ReleaseNoten er benyttet av: "}
+              <BoldText>
+                {releases.map((r, i) => {
+                  return releases[i + 1] ? r.title + ", " : r.title;
+                })}
+              </BoldText>
+            </DialogContentText>
+          ) : (
+            ""
+          )}
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose} color="primary">
@@ -67,5 +91,14 @@ DeleteDialogButton.propTypes = {
   /**
    * Name of the entity to be deleted, e.g. "ReleaseNote" or "Product"
    */
-  entityName: PropTypes.string
+  entityName: PropTypes.string,
+
+  /**
+   * ID of the entity to be deleted
+   */
+  id: PropTypes.number.isRequired,
 };
+
+const BoldText = styled.div`
+  font-weight: bold;
+`;

--- a/src/components/shared/DeleteDialogButton.jsx
+++ b/src/components/shared/DeleteDialogButton.jsx
@@ -18,12 +18,10 @@ export default function DeleteDialogButton(props) {
 
   const fetchData = async () => {
     var releaseNote = await getReleaseNoteWithReleases(props.id);
-    console.log(releaseNote);
     setReleases(releaseNote.releases);
   };
 
   const handleClickOpen = () => {
-    console.log(props);
     fetchData();
     setOpen(true);
   };

--- a/src/slices/releaseNoteSlice.js
+++ b/src/slices/releaseNoteSlice.js
@@ -33,19 +33,19 @@ export const releaseNoteReducer = createReducer(
     },
     [deleteSuccess]: (state, action) => {
       deleteInArray(state, action);
-    }
+    },
   }
 );
 
 // THUNKS
 export function fetchReleaseNoteById(id) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch(getByIdPending({ id }));
     return Axios.get("/releasenote/" + id)
-      .then(response => {
+      .then((response) => {
         dispatch(getByIdSuccess({ data: response.data, id }));
       })
-      .catch(error => {
+      .catch((error) => {
         getByIdError({ error, id });
       });
   };
@@ -53,51 +53,62 @@ export function fetchReleaseNoteById(id) {
 
 export function fetchReleaseNotes(_query) {
   const query = _query ? _query : "";
-  return dispatch => {
+  return (dispatch) => {
     dispatch(getPending());
     return Axios.get("/releasenote" + query)
-      .then(res => {
+      .then((res) => {
         dispatch(getSuccess({ data: res.data }));
       })
-      .catch(error => {
+      .catch((error) => {
         getError(error);
       });
   };
 }
 
 export function putReleaseNote(id, note) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch(savePending({ id }));
     return Axios.put("/releasenote/" + id, note)
-      .then(response => {
+      .then((response) => {
         dispatch(saveSuccess({ data: response.data, id }));
       })
-      .catch(error => {
+      .catch((error) => {
         saveError({ error, id });
       });
   };
 }
 
 export function postReleaseNote(note) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch(savePending());
     return Axios.post("/releasenote/", note)
-      .then(response => {
+      .then((response) => {
         dispatch(saveSuccess({ data: response.data, id: response.data.id }));
       })
-      .catch(error => {
+      .catch((error) => {
         saveError({ error });
       });
   };
 }
+
+export const getReleaseNoteWithReleases = async (id) => {
+  return await Axios.get("releasenote/" + id + "?includeReleases")
+    .then((res) => {
+      return res.data;
+    })
+    .catch((err) => {
+      return "";
+    });
+};
+
 export function deleteReleaseNote(id) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch(deletePending());
     return Axios.delete("/releasenote/" + id)
-      .then(response => {
+      .then((response) => {
         dispatch(deleteSuccess({ id }));
       })
-      .catch(error => {
+      .catch((error) => {
         dispatch(deleteError(error));
       });
   };


### PR DESCRIPTION
Når en bruker nå klikker på "søppelbøtta" til en Release Note, så dukker også assosierte Releases opp i vinduet.

![image](https://user-images.githubusercontent.com/33400600/78562913-6a87f800-781a-11ea-8123-1c07deb2a13b.png)
