### PR TITLE
Bugfix/blank work items

### DIFF
--- a/src/slices/azureSlice.js
+++ b/src/slices/azureSlice.js
@@ -1,8 +1,6 @@
 import { createReducer, createAction } from "@reduxjs/toolkit";
 import GlobalAxios from "axios";
 import { postRelease } from "./releaseSlice";
-const util = require('util')
-
 
 // azure axios instance
 export const AzureAxios = GlobalAxios.create({
@@ -196,9 +194,7 @@ export const importRelease = (
         // Format and filter each work item
         rawWorkItems.forEach((wi) => {
           workItems.push(createWorkItem(wi));
-          console.log("1: " + util.inspect(workItems, false, null, false));
         });
-
 
         // Create new release and post
         const release = {
@@ -207,8 +203,6 @@ export const importRelease = (
           ProductVersionId: productVersionId,
           releaseNotes: workItems
         };
-        console.log("2: " + util.inspect(release, false, null, false))
-
 
         // Post release
         dispatch(postRelease(release));
@@ -220,8 +214,14 @@ export const importRelease = (
   }
 };
 
-// util
+// utils
 export const createWorkItem = (item) => {
+  var desc = item.fields["System.Description"];
+  // does it exist or what?!?!?!?
+  if (isEmpty(desc)) {
+    //yes
+    desc = "Vennligst lag en description";
+  }
   return {
     WorkItemId: item.id,
     WorkItemTitle: item.fields["System.Title"],
@@ -231,6 +231,10 @@ export const createWorkItem = (item) => {
     AuthorEmail: item.fields["System.CreatedBy"]["uniqueName"],
     title: item.fields["System.Title"],
     ingress: "",
-    Description: item.fields["System.Description"]
+    Description: desc
   };
 };
+
+function isEmpty(str) {
+  return (!str || 0 === str.length);
+}

--- a/src/slices/azureSlice.js
+++ b/src/slices/azureSlice.js
@@ -229,7 +229,7 @@ export const importRelease = (
 export const createWorkItem = (item) => {
   var desc = item.fields["System.Description"];
   if (isEmpty(desc)) {
-    desc = "Vennligst lag en description";
+    desc = "";
   }
   return {
     WorkItemId: item.id,

--- a/src/slices/azureSlice.js
+++ b/src/slices/azureSlice.js
@@ -1,6 +1,8 @@
 import { createReducer, createAction } from "@reduxjs/toolkit";
 import GlobalAxios from "axios";
 import { postRelease } from "./releaseSlice";
+const util = require('util')
+
 
 // azure axios instance
 export const AzureAxios = GlobalAxios.create({
@@ -194,15 +196,19 @@ export const importRelease = (
         // Format and filter each work item
         rawWorkItems.forEach((wi) => {
           workItems.push(createWorkItem(wi));
+          console.log("1: " + util.inspect(workItems, false, null, false));
         });
+
 
         // Create new release and post
         const release = {
           title: title,
           isPublic: false,
-          productVersionId: productVersionId,
-          releaseNotes: workItems,
+          ProductVersionId: productVersionId,
+          releaseNotes: workItems
         };
+        console.log("2: " + util.inspect(release, false, null, false))
+
 
         // Post release
         dispatch(postRelease(release));
@@ -223,5 +229,8 @@ export const createWorkItem = (item) => {
     WorkItemDescriptionHtml: item.fields["System.Description"],
     AuthorName: item.fields["System.CreatedBy"]["displayName"],
     AuthorEmail: item.fields["System.CreatedBy"]["uniqueName"],
+    title: item.fields["System.Title"],
+    ingress: "",
+    Description: item.fields["System.Description"]
   };
 };

--- a/src/slices/azureSlice.js
+++ b/src/slices/azureSlice.js
@@ -231,7 +231,6 @@ export const createWorkItem = (item) => {
   if (isEmpty(desc)) {
     desc = "Vennligst lag en description";
   }
-
   return {
     WorkItemId: item.id,
     WorkItemTitle: item.fields["System.Title"],

--- a/src/slices/azureSlice.test.js
+++ b/src/slices/azureSlice.test.js
@@ -82,7 +82,7 @@ const mappedWorkitem = {
   AuthorEmail: "markuran@ntnu.no",
   ingress: "",
   title: "Som en administrator kan jeg legge til Autentiserings-informasjon til Azure Devops.",
-  Description: "<div>Wireframe:</div> <div><a href=\"https://confluence.uials.no/pages/viewpage.action?pageId=57378685\">https://confluence.uials.no/pages/viewpage.action?pageId=57378685</a></div> <div><br></div><div>ERD:</div><div><a href=\"https://confluence.uials.no/pages/viewpage.action?pageId=57377417\">https://confluence.uials.no/pages/viewpage.action?pageId=57377417</a><br></div>",
+  Description: '<div>Wireframe:</div><div><a href="https://confluence.uials.no/pages/viewpage.action?pageId=57378685">https://confluence.uials.no/pages/viewpage.action?pageId=57378685</a></div><div><br></div><div>ERD:</div><div><a href="https://confluence.uials.no/pages/viewpage.action?pageId=57377417">https://confluence.uials.no/pages/viewpage.action?pageId=57377417</a><br></div>',
 };
 
 const dummyWorkItemRaw = {

--- a/src/slices/azureSlice.test.js
+++ b/src/slices/azureSlice.test.js
@@ -82,21 +82,21 @@ const mappedWorkitem = {
   AuthorEmail: "markuran@ntnu.no",
   ingress: "",
   title: "Som en administrator kan jeg legge til Autentiserings-informasjon til Azure Devops.",
-  Description": "<div>Wireframe:</div> <div><a href=\"https://confluence.uials.no/pages/viewpage.action?pageId=57378685\">https://confluence.uials.no/pages/viewpage.action?pageId=57378685</a></div> <div><br></div><div>ERD:</div><div><a href=\"https://confluence.uials.no/pages/viewpage.action?pageId=57377417\">https://confluence.uials.no/pages/viewpage.action?pageId=57377417</a><br></div>",
+  Description: "<div>Wireframe:</div> <div><a href=\"https://confluence.uials.no/pages/viewpage.action?pageId=57378685\">https://confluence.uials.no/pages/viewpage.action?pageId=57378685</a></div> <div><br></div><div>ERD:</div><div><a href=\"https://confluence.uials.no/pages/viewpage.action?pageId=57377417\">https://confluence.uials.no/pages/viewpage.action?pageId=57377417</a><br></div>",
 };
 
 const dummyWorkItemRaw = {
-      id: 224,
+  id: 224,
   rev: 10,
   fields: {
-      "System.CreatedDate": "2020-03-25T16:22:24.503Z",
+    "System.CreatedDate": "2020-03-25T16:22:24.503Z",
     "System.CreatedBy": {
       displayName: "Markus Randa",
       url:
         "https://spsprodweu1.vssps.visualstudio.com/A025f0995-ba99-4e30-998a-739dc40106c6/_apis/Identities/daab4d46-973a-64b4-9795-742508e96bfc",
       _links: {
-      avatar: {
-      href:
+        avatar: {
+          href:
             "https://dev.azure.com/ReleaseNoteSystem/_apis/GraphProfile/MemberAvatars/aad.ZGFhYjRkNDYtOTczYS03NGI0LTk3OTUtNzQyNTA4ZTk2YmZj",
         },
       },
@@ -115,10 +115,10 @@ const dummyWorkItemRaw = {
 };
 
 const dummyReleases = {
-        count: 17,
+  count: 17,
   value: [
     {
-        id: 18,
+      id: 18,
       name: "Release-18",
       status: "abandoned",
       createdOn: "2017-06-16T01:36:20.397Z",
@@ -149,12 +149,12 @@ const dummyReleases = {
         url:
           "https://vsrm.dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_apis/Release/definitions/1",
         _links: {
-        self: {
-        href:
+          self: {
+            href:
               "https://vsrm.dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_apis/Release/definitions/1",
           },
           web: {
-        href:
+            href:
               "https://dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_release?definitionId=1",
           },
         },
@@ -170,11 +170,11 @@ const dummyReleases = {
         "https://vsrm.dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_apis/Release/releases/18",
       _links: {
         self: {
-        href:
+          href:
             "https://vsrm.dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_apis/Release/releases/18",
         },
         web: {
-        href:
+          href:
             "https://dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_release?releaseId=18&_a=release-summary",
         },
       },
@@ -186,7 +186,7 @@ const dummyReleases = {
       properties: {},
     },
     {
-        id: 17,
+      id: 17,
       name: "Release-17",
       status: "active",
       createdOn: "2017-06-16T01:36:19.35Z",
@@ -217,12 +217,12 @@ const dummyReleases = {
         url:
           "https://vsrm.dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_apis/Release/definitions/1",
         _links: {
-        self: {
-        href:
+          self: {
+            href:
               "https://vsrm.dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_apis/Release/definitions/1",
           },
           web: {
-        href:
+            href:
               "https://dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_release?definitionId=1",
           },
         },
@@ -232,10 +232,10 @@ const dummyReleases = {
 };
 
 const dummyProjects = {
-        count: 1,
+  count: 1,
   value: [
     {
-        id: "kkkkceeeexxx-9999-ffff-bbbb-kkkkceeeexxx",
+      id: "kkkkceeeexxx-9999-ffff-bbbb-kkkkceeeexxx",
       name: "Dummy project",
       description: "dummy",
       url:

--- a/src/slices/azureSlice.test.js
+++ b/src/slices/azureSlice.test.js
@@ -80,20 +80,23 @@ const mappedWorkitem = {
     '<div>Wireframe:</div><div><a href="https://confluence.uials.no/pages/viewpage.action?pageId=57378685">https://confluence.uials.no/pages/viewpage.action?pageId=57378685</a></div><div><br></div><div>ERD:</div><div><a href="https://confluence.uials.no/pages/viewpage.action?pageId=57377417">https://confluence.uials.no/pages/viewpage.action?pageId=57377417</a><br></div>',
   AuthorName: "Markus Randa",
   AuthorEmail: "markuran@ntnu.no",
+  ingress: "",
+  title: "Som en administrator kan jeg legge til Autentiserings-informasjon til Azure Devops.",
+  Description": "<div>Wireframe:</div> <div><a href=\"https://confluence.uials.no/pages/viewpage.action?pageId=57378685\">https://confluence.uials.no/pages/viewpage.action?pageId=57378685</a></div> <div><br></div><div>ERD:</div><div><a href=\"https://confluence.uials.no/pages/viewpage.action?pageId=57377417\">https://confluence.uials.no/pages/viewpage.action?pageId=57377417</a><br></div>",
 };
 
 const dummyWorkItemRaw = {
-  id: 224,
+      id: 224,
   rev: 10,
   fields: {
-    "System.CreatedDate": "2020-03-25T16:22:24.503Z",
+      "System.CreatedDate": "2020-03-25T16:22:24.503Z",
     "System.CreatedBy": {
       displayName: "Markus Randa",
       url:
         "https://spsprodweu1.vssps.visualstudio.com/A025f0995-ba99-4e30-998a-739dc40106c6/_apis/Identities/daab4d46-973a-64b4-9795-742508e96bfc",
       _links: {
-        avatar: {
-          href:
+      avatar: {
+      href:
             "https://dev.azure.com/ReleaseNoteSystem/_apis/GraphProfile/MemberAvatars/aad.ZGFhYjRkNDYtOTczYS03NGI0LTk3OTUtNzQyNTA4ZTk2YmZj",
         },
       },
@@ -112,10 +115,10 @@ const dummyWorkItemRaw = {
 };
 
 const dummyReleases = {
-  count: 17,
+        count: 17,
   value: [
     {
-      id: 18,
+        id: 18,
       name: "Release-18",
       status: "abandoned",
       createdOn: "2017-06-16T01:36:20.397Z",
@@ -146,12 +149,12 @@ const dummyReleases = {
         url:
           "https://vsrm.dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_apis/Release/definitions/1",
         _links: {
-          self: {
-            href:
+        self: {
+        href:
               "https://vsrm.dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_apis/Release/definitions/1",
           },
           web: {
-            href:
+        href:
               "https://dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_release?definitionId=1",
           },
         },
@@ -167,11 +170,11 @@ const dummyReleases = {
         "https://vsrm.dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_apis/Release/releases/18",
       _links: {
         self: {
-          href:
+        href:
             "https://vsrm.dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_apis/Release/releases/18",
         },
         web: {
-          href:
+        href:
             "https://dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_release?releaseId=18&_a=release-summary",
         },
       },
@@ -183,7 +186,7 @@ const dummyReleases = {
       properties: {},
     },
     {
-      id: 17,
+        id: 17,
       name: "Release-17",
       status: "active",
       createdOn: "2017-06-16T01:36:19.35Z",
@@ -214,12 +217,12 @@ const dummyReleases = {
         url:
           "https://vsrm.dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_apis/Release/definitions/1",
         _links: {
-          self: {
-            href:
+        self: {
+        href:
               "https://vsrm.dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_apis/Release/definitions/1",
           },
           web: {
-            href:
+        href:
               "https://dev.azure.com/fabrikam/d07908bc-118f-47d2-8a13-ff75601a6b1a/_release?definitionId=1",
           },
         },
@@ -229,10 +232,10 @@ const dummyReleases = {
 };
 
 const dummyProjects = {
-  count: 1,
+        count: 1,
   value: [
     {
-      id: "kkkkceeeexxx-9999-ffff-bbbb-kkkkceeeexxx",
+        id: "kkkkceeeexxx-9999-ffff-bbbb-kkkkceeeexxx",
       name: "Dummy project",
       description: "dummy",
       url:


### PR DESCRIPTION
fikset bug og lagt til en default description på importerte work items ikke har en description. 

Eksempel med work item som har en description:
![bilde](https://user-images.githubusercontent.com/26660106/79559788-a5a1eb00-80a6-11ea-98f0-64edfa7f8789.png)

Eksempel på work item med description:
![bilde](https://user-images.githubusercontent.com/26660106/79559926-d8e47a00-80a6-11ea-95ee-8788c70e80ea.png)


Det ser og er en del redudant kode her, men det er nødvendig grunnet måten release note i api e bygget.
![bilde](https://user-images.githubusercontent.com/26660106/79562319-29f66d00-80ab-11ea-8fa4-2d314fbe718e.png)

Anser den refaktoringen som en annen oppgave siden den kan bringe en del bugs