### PR TITLE
Flyttet på AzureProjectSelector AB#318

### DIFF
--- a/src/components/adminpanel/AzureDevOpsView.jsx
+++ b/src/components/adminpanel/AzureDevOpsView.jsx
@@ -16,9 +16,6 @@ import {
 const AzureDevOpsView = (props) => {
   const {
     azureReleases,
-    azureProjects,
-    handleSelectedProject,
-    selectedProject,
     handleImport,
     selectedProductVersion,
     handleSelectedProductVersion,
@@ -43,7 +40,7 @@ const AzureDevOpsView = (props) => {
 
   return (
     <React.Fragment>
-      <DevOpsForm />
+      <DevOpsForm {...props} />
       <AdminExpansionPanelBase
         expanded
         label="Azure Devops Releases"
@@ -51,20 +48,12 @@ const AzureDevOpsView = (props) => {
           <Grid container>
             <Grid item>
               <GeneralSelector
-                items={azureProjects}
-                selected={selectedProject}
-                handleChange={handleSelectedProject}
-                label="Prosjekt"
-                helperText="Velg et prosjekt"
-              />
-            </Grid>
-            <Grid item>
-              <GeneralSelector
                 items={productVersions}
                 selected={selectedProductVersion}
                 handleChange={handleSelectedProductVersion}
                 label="Produkt"
                 helperText="Velg et produkt å importere til"
+                ml={25}
               />
             </Grid>
           </Grid>

--- a/src/components/adminpanel/DevOpsForm.jsx
+++ b/src/components/adminpanel/DevOpsForm.jsx
@@ -40,7 +40,7 @@ const DevOpsForm = () => {
       <MyGrid container spacing={1} direction="column" justify="center">
         <Grid item>
           <Typography variant="body1" style={{ marginBottom: "1.2em" }}>
-            Azure Integrasjon
+                Azure Pålogging
           </Typography>
         </Grid>
         <Grid item>

--- a/src/components/adminpanel/DevOpsForm.jsx
+++ b/src/components/adminpanel/DevOpsForm.jsx
@@ -7,8 +7,10 @@ import { useState, useEffect } from "react";
 import Typography from "@material-ui/core/Typography";
 import { updateAzureInfo, fetchAzureInfo } from "../../slices/authSlice";
 import { useDispatch, useSelector } from "react-redux";
+import GeneralSelector from "../shared/GeneralSelector";
 
-const DevOpsForm = () => {
+const DevOpsForm = (props) => {
+  const { azureProjects, handleSelectedProject, selectedProject } = props;
   const [name, setName] = useState("");
   const [PAT, setPAT] = useState("");
   const [org, setOrg] = useState("");
@@ -37,50 +39,72 @@ const DevOpsForm = () => {
 
   return (
     <MyPaper>
-      <MyGrid container spacing={1} direction="column" justify="center">
+      <Grid container spacing={7} direction="row">
         <Grid item>
-          <Typography variant="body1" style={{ marginBottom: "1.2em" }}>
+          <MyGrid container spacing={1} direction="column" justify="center">
+            <Grid item>
+              <Typography variant="body1" style={{ marginBottom: "1.2em" }}>
                 Azure Pålogging
-          </Typography>
+              </Typography>
+            </Grid>
+            <Grid item>
+              <TextField
+                id="standard-required DevOpsName"
+                label="DevOps Brukernavn"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </Grid>
+            <Grid item>
+              <TextField
+                id="standard-required DevOpsOrg"
+                label="DevOps Organisasjon"
+                value={org}
+                onChange={(e) => setOrg(e.target.value)}
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextField
+                fullWidth
+                id="standard-required DevOpsPAT"
+                label="Personal Access Token"
+                value={PAT}
+                onChange={(e) => setPAT(e.target.value)}
+              />
+            </Grid>
+            <Grid>
+              <MyButton
+                variant="contained"
+                color="primary"
+                id="sendDataBtn"
+                onClick={handleSubmit}
+              >
+                Lagre
+              </MyButton>
+            </Grid>
+          </MyGrid>
         </Grid>
         <Grid item>
-          <TextField
-            id="standard-required DevOpsName"
-            label="DevOps Brukernavn"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
+          <MyGrid container spacing={1} direction="column" justify="center">
+            <Grid item>
+              {/* Don't touch marginBottom, it's perfect */}
+              <Typography variant="body1" style={{ marginBottom: "13px" }}>
+                Azure Prosjekt
+              </Typography>
+            </Grid>
+            <Grid item>
+              <GeneralSelector
+                items={azureProjects}
+                selected={selectedProject}
+                handleChange={handleSelectedProject}
+                label="Prosjekt"
+                helperText="Velg et prosjekt"
+              />
+            </Grid>
+          </MyGrid>
         </Grid>
-        <Grid item>
-          <TextField
-            id="standard-required DevOpsOrg"
-            label="DevOps Organisasjon"
-            value={org}
-            onChange={(e) => setOrg(e.target.value)}
-          />
-        </Grid>
-        <Grid item xs={12}>
-          <TextField
-            fullWidth
-            id="standard-required DevOpsPAT"
-            label="Personal Access Token"
-            value={PAT}
-            onChange={(e) => setPAT(e.target.value)}
-          />
-        </Grid>
-        <Grid>
-          <MyButton
-            variant="contained"
-            color="primary"
-            id="sendDataBtn"
-            onClick={handleSubmit}
-          >
-            Lagre
-          </MyButton>
-        </Grid>
-      </MyGrid>
+      </Grid>
     </MyPaper>
-
   );
 };
 

--- a/src/components/shared/GeneralSelector.jsx
+++ b/src/components/shared/GeneralSelector.jsx
@@ -13,10 +13,24 @@ import styled from "styled-components";
  * @param {*} props.items Must be an array with objects containing id and value or be a single fielded
  */
 const GeneralSelector = (props) => {
-  const { items, selected, handleChange, helperText, label } = props;
+  const { items, selected, handleChange, helperText, label, ml } = props;
 
   return (
-    <StyledFormControl>
+    <StyledFormControl
+      adornedStartfalse
+      color="primary"
+      disabledfalse
+      errorfalse
+      filledtrue
+      focusedfalse
+      fullWidthfalse
+      hiddenLabelfalse
+      margin="none"
+      requiredfalse
+      variant="standard"
+      ml={ml ? ml : 0}
+    >
+      {helperText ? <FormHelperText>{helperText}</FormHelperText> : ""}
       <Select label={label} value={selected} onChange={handleChange}>
         {items.map((obj) => (
           <MenuItem key={typeof obj === "string" ? obj : obj.id} value={obj}>
@@ -24,19 +38,19 @@ const GeneralSelector = (props) => {
           </MenuItem>
         ))}
       </Select>
-      <FormHelperText>{helperText}</FormHelperText>
     </StyledFormControl>
   );
 };
 
 GeneralSelector.prototype = {
   items: PropTypes.array,
+  ml: PropTypes.string,
 };
 
 export default GeneralSelector;
 
 const StyledFormControl = styled(FormControl)`
   && {
-    margin-left: 25px;
+    margin-left: ${(props) => (props.ml ? props.ml : 0)}px;
   }
 `;


### PR DESCRIPTION
Det som er gjort i denne PR er at selector for Azure-prosjekter er flyttet lengre opp, grunnen til at jeg ønsker denne endringen er fordi denne funksjonaliteten brukes igjen senere i samme view.

![image](https://user-images.githubusercontent.com/33400600/79564550-295fd580-80af-11ea-8591-6ea3b9d70350.png)
