### PR TITLE
Bruker kunne ikke se produkter med Chrome AB#328

### DIFF
--- a/src/components/product/Product.jsx
+++ b/src/components/product/Product.jsx
@@ -40,12 +40,6 @@ const Product = (props) => {
                   <Typography variant="h4" component="h2">
                     {props.item.name}
                   </Typography>
-                  <Typography>adjective</Typography>
-                  <Typography variant="body2" component="p">
-                    well meaning and kindly.
-                    <br />
-                    {'"a benevolent smile"'}
-                  </Typography>
                 </ProductCardContent>
               </Grid>
             </Grid>

--- a/src/components/product/Product.jsx
+++ b/src/components/product/Product.jsx
@@ -78,7 +78,7 @@ const ProductCardContent = styled(CardContent)`
 
 const CardImage = styled(CardMedia)`
   && {
-    max-width: auto 400px;
+    max-width: 400px;
     max-height: 250px;
   }
 `;


### PR DESCRIPTION
En kriminell har benyttet seg av propertien `max-width: auto` som ikke lar seg bruke i Chrome, dette er nå reparert.

Har også lagt inn en snikendring der jeg fjernet placeholder-tekst.