### PR TITLE
Ready-switch i ReleaseNoteEditor fungerer nå som den skal

### DIFF
--- a/src/components/releaseNoteEditor/ReleaseNoteEditor.jsx
+++ b/src/components/releaseNoteEditor/ReleaseNoteEditor.jsx
@@ -56,6 +56,7 @@ const ReleaseNoteEditor = (props) => {
     setTitle(createStateFromText(props.note.title));
     setIngress(createStateFromText(props.note.ingress));
     setDescription(createStateFromText(props.note.description));
+    setReady(props.note.isPublic);
   }, [props.note]);
 
   // update the given editor


### PR DESCRIPTION
- Added initial value for "ready-switch".