### PR TITLE
Selector for workItemtype && Integrasjon av tabell-endringer

### DIFF
--- a/src/components/adminpanel/AzureMappingView.jsx
+++ b/src/components/adminpanel/AzureMappingView.jsx
@@ -44,7 +44,9 @@ const AzureMappingView = (props) => {
   });
   const [localMappings, setLocalMappings] = useState([{}]);
   const [workItemTypes] = useState(["task", "bug"]);
-  const [selectedWorkItemType, setSelectedWorkItemType] = useState("task");
+  const [selectedWorkItemType, setSelectedWorkItemType] = useState(
+    workItemTypes[0]
+  );
 
   // ------- DATA FETCHING -------
   useEffect(() => {
@@ -121,9 +123,11 @@ const AzureMappingView = (props) => {
             var tableObject = localMappings[index];
 
             // Get id of mapping
-            var mappingId = tableObject.id;
+            var rnsFieldName = tableObject.rnsFieldName;
 
-            dispatch(putMapping(mappingId, newAzdField, selectedWorkItemType));
+            dispatch(
+              putMapping(rnsFieldName, newAzdField, selectedWorkItemType)
+            );
           } catch {
             throw new Error("Couldn't find object");
           }

--- a/src/components/adminpanel/AzureMappingView.jsx
+++ b/src/components/adminpanel/AzureMappingView.jsx
@@ -55,13 +55,23 @@ const AzureMappingView = (props) => {
 
   useEffect(() => {
     const { authToken, organization } = azureProps;
-    if (authToken === "" || selectedProject === "" || organization === "")
+    if (
+      authToken === "" ||
+      selectedProject === "" ||
+      organization === "" ||
+      selectedWorkItemType === ""
+    )
       return;
     if (!authToken || !selectedProject || !organization) return;
     dispatch(
-      fetchAZDMappable(authToken, selectedProject, organization, "task")
+      fetchAZDMappable(
+        authToken,
+        selectedProject,
+        organization,
+        selectedWorkItemType
+      )
     );
-  }, [dispatch, azureProps, selectedProject]);
+  }, [dispatch, azureProps, selectedProject, selectedWorkItemType]);
 
   const azdFields = useSelector(AZDTableFieldSelector);
   const rnsMappings = useSelector(rnsMappingsTableFields);

--- a/src/components/adminpanel/AzureMappingView.jsx
+++ b/src/components/adminpanel/AzureMappingView.jsx
@@ -45,7 +45,7 @@ const AzureMappingView = (props) => {
   });
 
   const [localMappings, setLocalMappings] = useState([{}]);
-  const [workItemTypes, setWorkItemTypes] = useState(["task", "bug"]);
+  const [workItemTypes] = useState(["task", "bug"]);
   const [selectedWorkItemType, setSelectedWorkItemType] = useState("task");
 
   useEffect(() => {

--- a/src/components/adminpanel/AzureMappingView.jsx
+++ b/src/components/adminpanel/AzureMappingView.jsx
@@ -131,6 +131,7 @@ const AzureMappingView = (props) => {
     // Azure, we need to add these as lookup-options.
     addMissingLookupElements();
 
+    // If there's no lookup to bind azdFields to, just set mappings and return
     if (!lookup || lookup[0] === "") {
       setLocalMappings(rnsMappings);
       return;

--- a/src/components/adminpanel/AzureMappingView.jsx
+++ b/src/components/adminpanel/AzureMappingView.jsx
@@ -23,7 +23,6 @@ import Search from "@material-ui/icons/Search";
 import ViewColumn from "@material-ui/icons/ViewColumn";
 import { useSelector, useDispatch } from "react-redux";
 import {
-  fetchRNSMappable,
   fetchAZDMappable,
   AZDTableFieldSelector,
   fetchRNSMappings,
@@ -39,19 +38,18 @@ const AzureMappingView = (props) => {
   const rnsTableRef = React.createRef();
   const dispatch = useDispatch();
 
-  // The state of the available AzureDevOps-fields.
+  // ------- STATES -------
   const [lookup, setLookup] = useState({
     0: "",
   });
-
   const [localMappings, setLocalMappings] = useState([{}]);
   const [workItemTypes] = useState(["task", "bug"]);
   const [selectedWorkItemType, setSelectedWorkItemType] = useState("task");
 
+  // ------- DATA FETCHING -------
   useEffect(() => {
-    dispatch(fetchRNSMappable());
-    dispatch(fetchRNSMappings());
-  }, [dispatch]);
+    dispatch(fetchRNSMappings(selectedWorkItemType));
+  }, [dispatch, selectedWorkItemType]);
 
   useEffect(() => {
     const { authToken, organization } = azureProps;
@@ -76,7 +74,7 @@ const AzureMappingView = (props) => {
   const azdFields = useSelector(AZDTableFieldSelector);
   const rnsMappings = useSelector(rnsMappingsTableFields);
 
-  // Updates the fields
+  // ------- UPDATE DATA -------
   useEffect(() => {
     if (!rnsMappings) return;
     if (!lookup || lookup[0] === "") {
@@ -102,6 +100,7 @@ const AzureMappingView = (props) => {
     setLocalMappings(rnsMappings);
   }, [lookup, rnsMappings]);
 
+  // Update local state with all the available fields from Azure
   useEffect(() => {
     // If there's no members in object, just return
     if (Object.keys(azdFields).length === 0 && azdFields.constructor === Object)
@@ -115,7 +114,7 @@ const AzureMappingView = (props) => {
         new Promise((resolve, reject) => {
           try {
             // Get the field name to set
-            const result = lookup[newData.azdFieldName];
+            const newAzdField = lookup[newData.azdFieldName];
 
             // Get tableObject
             var index = localMappings.indexOf(oldData);
@@ -124,7 +123,7 @@ const AzureMappingView = (props) => {
             // Get id of mapping
             var mappingId = tableObject.id;
 
-            dispatch(putMapping(mappingId, result));
+            dispatch(putMapping(mappingId, newAzdField, selectedWorkItemType));
           } catch {
             throw new Error("Couldn't find object");
           }

--- a/src/components/adminpanel/AzureMappingView.jsx
+++ b/src/components/adminpanel/AzureMappingView.jsx
@@ -133,7 +133,6 @@ const AzureMappingView = (props) => {
   };
 
   const handleSelectedWorkItemType = (event) => {
-    console.log(event.currentTarget.textContent);
     setSelectedWorkItemType(event.currentTarget.textContent);
   };
 
@@ -172,9 +171,7 @@ const AzureMappingView = (props) => {
         ]}
         data={localMappings}
         editable={getEditable()}
-        // actions={actionsMappingTable(rnsTableRef)}
         options={optionsMappingTable}
-        // components={getAzureDevOpsFieldSelector()}
       />
     </ExpansionPanel>
   );

--- a/src/components/adminpanel/AzureMappingView.jsx
+++ b/src/components/adminpanel/AzureMappingView.jsx
@@ -32,6 +32,7 @@ import {
 } from "../../slices/mappingSlice";
 import PropTypes from "prop-types";
 import { useState } from "react";
+import GeneralSelector from "../shared/GeneralSelector";
 
 const AzureMappingView = (props) => {
   const { azureProps, selectedProject } = props;
@@ -44,6 +45,8 @@ const AzureMappingView = (props) => {
   });
 
   const [localMappings, setLocalMappings] = useState([{}]);
+  const [workItemTypes, setWorkItemTypes] = useState(["task", "bug"]);
+  const [selectedWorkItemType, setSelectedWorkItemType] = useState("task");
 
   useEffect(() => {
     dispatch(fetchRNSMappable());
@@ -120,6 +123,11 @@ const AzureMappingView = (props) => {
     };
   };
 
+  const handleSelectedWorkItemType = (event) => {
+    console.log(event.currentTarget.textContent);
+    setSelectedWorkItemType(event.currentTarget.textContent);
+  };
+
   return (
     <ExpansionPanel>
       <ExpansionPanelSummary
@@ -129,6 +137,13 @@ const AzureMappingView = (props) => {
       >
         <Typography>Release Note Mapping</Typography>
       </ExpansionPanelSummary>
+      <GeneralSelector
+        items={workItemTypes}
+        selected={selectedWorkItemType}
+        handleChange={handleSelectedWorkItemType}
+        helperText="Velg en Work-Item Type"
+        ml={25}
+      />
       <MaterialTable
         icons={tableIcons}
         tableRef={rnsTableRef}

--- a/src/components/shared/GeneralSelector.jsx
+++ b/src/components/shared/GeneralSelector.jsx
@@ -43,7 +43,8 @@ const GeneralSelector = (props) => {
 };
 
 GeneralSelector.prototype = {
-  items: PropTypes.array,
+  items: PropTypes.array.isRequired,
+  selected: PropTypes.any.isRequired,
   ml: PropTypes.string,
 };
 

--- a/src/constants/userFeedback.js
+++ b/src/constants/userFeedback.js
@@ -1,0 +1,2 @@
+export const ERROR_WORK_ITEM_TYPE_NOT_PROVIDED =
+  "Vennligst velg en work item type.";

--- a/src/slices/mappingSlice.js
+++ b/src/slices/mappingSlice.js
@@ -8,6 +8,8 @@ export const AzureAxios = GlobalAxios.create({
   timeout: 5000,
 });
 
+const ERROR_WORK_ITEM_TYPE_NOT_PROVIDED = "You need to provide a WormItemType!";
+
 /*
     RNS == Release Note System
     AZD == Azure DevOps
@@ -133,8 +135,11 @@ const buildWorkitemTypeURL = (project, org, itemType) => {
   );
 };
 
-export const fetchRNSMappings = () => async (dispatch) => {
+export const fetchRNSMappings = (type) => async (dispatch) => {
+  if (!type || type === "") throw Error(ERROR_WORK_ITEM_TYPE_NOT_PROVIDED);
+
   const url = "/MappableFields?mapped";
+
   dispatch(fetchRNSMappingsPending());
   Axios.get(url)
     .then((res) => {
@@ -145,7 +150,9 @@ export const fetchRNSMappings = () => async (dispatch) => {
     });
 };
 
-export const putMapping = (id, data) => async (dispatch) => {
+export const putMapping = (id, data, workItemType) => async (dispatch) => {
+  if (!workItemType || workItemType === "")
+    throw Error(ERROR_WORK_ITEM_TYPE_NOT_PROVIDED);
   const url = "/MappableFields/" + id;
   const object = { azureDevOpsField: data };
 

--- a/src/slices/mappingSlice.js
+++ b/src/slices/mappingSlice.js
@@ -9,8 +9,6 @@ export const AzureAxios = GlobalAxios.create({
   timeout: 5000,
 });
 
-const ERROR_WORK_ITEM_TYPE_NOT_PROVIDED = "You need to provide a WormItemType!";
-
 /*
     RNS == Release Note System
     AZD == Azure DevOps
@@ -74,7 +72,7 @@ export const mappingReducer = createReducer(initialState, {
 });
 
 // THUNKS
-export const fetchRNSMappable = () => async (dispatch) => {
+export const fetchRNSMappable = (itemType) => async (dispatch) => {
   dispatch(fetchRNSMappablePending());
   Axios.get("mappablefields/")
     .then((res) => {
@@ -130,7 +128,6 @@ const buildWorkitemTypeURL = (project, org, itemType) => {
     "?api-version=5.1"
   );
 };
-
 export const fetchRNSMappings = (type) => async (dispatch) => {
   if (!type || type === "") throw Error(ERROR_WORK_ITEM_TYPE_NOT_PROVIDED);
 

--- a/src/slices/mappingSlice.js
+++ b/src/slices/mappingSlice.js
@@ -62,7 +62,7 @@ export const mappingReducer = createReducer(initialState, {
     //todo implement update state with new mapping
     const incomingObject = action.payload.data.entity;
     const index = state.RNSMappings.entity.findIndex((obj) => {
-      return obj.id === incomingObject.id;
+      return obj.mappableField === incomingObject.mappableField;
     });
     if (index !== -1) {
       state.RNSMappings.entity[index].azureDevOpsField =
@@ -143,11 +143,14 @@ export const fetchRNSMappings = (type) => async (dispatch) => {
     });
 };
 
-export const putMapping = (id, data, workItemType) => async (dispatch) => {
+export const putMapping = (rnsField, newAzdField, workItemType) => async (
+  dispatch
+) => {
   if (!workItemType || workItemType === "")
     throw Error(ERROR_WORK_ITEM_TYPE_NOT_PROVIDED);
-  const url = "/MappableFields/" + id;
-  const object = { azureDevOpsField: data };
+  // {{base_url}}/api/MappableFields/task/title
+  const url = "/MappableFields/" + workItemType + "/" + rnsField;
+  const object = { azureDevOpsField: newAzdField };
 
   dispatch(putMappingPending());
   Axios.put(url, object)

--- a/src/slices/mappingSlice.js
+++ b/src/slices/mappingSlice.js
@@ -133,7 +133,7 @@ const buildWorkitemTypeURL = (project, org, itemType) => {
 export const fetchRNSMappings = (type) => async (dispatch) => {
   if (!type || type === "") throw Error(ERROR_WORK_ITEM_TYPE_NOT_PROVIDED);
 
-  const url = "/MappableFields?mapped";
+  const url = "/MappableFields?mapped&type=" + type;
 
   dispatch(fetchRNSMappingsPending());
   Axios.get(url)
@@ -221,8 +221,7 @@ export const rnsMappingsTableFields = createSelector(
   (fields) => {
     if (!fields) return;
     return fields.map((obj) => ({
-      id: obj.id,
-      rnsFieldName: obj.mappableField.name,
+      rnsFieldName: obj.mappableField,
       azureDevOpsField: obj.azureDevOpsField,
     }));
   }

--- a/src/slices/mappingSlice.js
+++ b/src/slices/mappingSlice.js
@@ -2,6 +2,7 @@ import { createAction, createReducer, createSelector } from "@reduxjs/toolkit";
 import GlobalAxios from "axios";
 import Axios from "axios";
 import { authHeader } from "../utils/azureUtils";
+import { ERROR_WORK_ITEM_TYPE_NOT_PROVIDED } from "../constants/userFeedback";
 
 // azure axios instance
 export const AzureAxios = GlobalAxios.create({

--- a/src/slices/mappingSlice.js
+++ b/src/slices/mappingSlice.js
@@ -129,7 +129,7 @@ const buildWorkitemTypeURL = (project, org, itemType) => {
   );
 };
 export const fetchRNSMappings = (type) => async (dispatch) => {
-  if (!type || type === "") throw Error(ERROR_WORK_ITEM_TYPE_NOT_PROVIDED);
+  if (!type) throw Error(ERROR_WORK_ITEM_TYPE_NOT_PROVIDED);
 
   const url = "/MappableFields?mapped&type=" + type;
 
@@ -146,8 +146,7 @@ export const fetchRNSMappings = (type) => async (dispatch) => {
 export const putMapping = (rnsField, newAzdField, workItemType) => async (
   dispatch
 ) => {
-  if (!workItemType || workItemType === "")
-    throw Error(ERROR_WORK_ITEM_TYPE_NOT_PROVIDED);
+  if (!workItemType) throw Error(ERROR_WORK_ITEM_TYPE_NOT_PROVIDED);
   // {{base_url}}/api/MappableFields/task/title
   const url = "/MappableFields/" + workItemType + "/" + rnsField;
   const object = { azureDevOpsField: newAzdField };


### PR DESCRIPTION
Her er det lagt inn en ny selector som benyttes for å hente data både fra ReleaseNoteSystem og AzureDevOps.

![image](https://user-images.githubusercontent.com/33400600/80187258-9cb59a00-860f-11ea-9a7f-728ad8dab527.png)

Det er også tatt hensyn til endringer som har skjedd i tabellene for mappings.