### PR TITLE
undefined descriptions are now handled

### DIFF
--- a/src/slices/azureSlice.js
+++ b/src/slices/azureSlice.js
@@ -242,7 +242,7 @@ export const createWorkItem = (item) => {
 };
 
 function isUndefined(str) {
-  return !str || str == null;
+  return !str || str === null || str === undefined;
 }
 
 function isEmpty(str) {

--- a/src/slices/azureSlice.js
+++ b/src/slices/azureSlice.js
@@ -220,9 +220,13 @@ export const importRelease = (
 
 // utils
 export const createWorkItem = (item) => {
-  var desc = item.fields["System.Description"];
+  let desc = item.fields["System.Description"];
   if (isEmpty(desc)) {
     desc = "";
+    if (isUndefined(desc)) {
+      desc = " ";
+      item.fields["System.Description"] = " ";
+    }
   }
   return {
     WorkItemId: item.id,
@@ -236,6 +240,10 @@ export const createWorkItem = (item) => {
     Description: desc,
   };
 };
+
+function isUndefined(str) {
+  return !str || str == null;
+}
 
 function isEmpty(str) {
   return !str || 0 === str.length;

--- a/src/slices/azureSlice.js
+++ b/src/slices/azureSlice.js
@@ -204,27 +204,3 @@ export const importRelease = (
       )
     );
 };
-
-// utils
-export const createWorkItem = (item) => {
-  let desc = item.fields["System.Description"];
-  if (isEmptyOrUndefined(desc)) {
-    desc = "";
-    item.fields["System.Description"] = "";
-  }
-  return {
-    WorkItemId: item.id,
-    WorkItemTitle: item.fields["System.Title"],
-    ClosedDate: item.fields["System.CreatedDate"],
-    WorkItemDescriptionHtml: item.fields["System.Description"],
-    AuthorName: item.fields["System.CreatedBy"]["displayName"],
-    AuthorEmail: item.fields["System.CreatedBy"]["uniqueName"],
-    title: item.fields["System.Title"],
-    ingress: "",
-    Description: desc,
-  };
-};
-
-function isEmptyOrUndefined(str) {
-  return !str || 0 === str.length || str == null;
-}

--- a/src/slices/azureSlice.js
+++ b/src/slices/azureSlice.js
@@ -222,8 +222,8 @@ export const importRelease = (
 export const createWorkItem = (item) => {
   let desc = item.fields["System.Description"];
   if (isEmptyOrUndefined(desc)) {
-    desc = " ";
-    item.fields["System.Description"] = " ";
+    desc = "";
+    item.fields["System.Description"] = "";
   }
   return {
     WorkItemId: item.id,

--- a/src/slices/azureSlice.js
+++ b/src/slices/azureSlice.js
@@ -221,12 +221,9 @@ export const importRelease = (
 // utils
 export const createWorkItem = (item) => {
   let desc = item.fields["System.Description"];
-  if (isEmpty(desc)) {
-    desc = "";
-    if (isUndefined(desc)) {
-      desc = " ";
-      item.fields["System.Description"] = " ";
-    }
+  if (isEmptyOrUndefined(desc)) {
+    desc = " ";
+    item.fields["System.Description"] = " ";
   }
   return {
     WorkItemId: item.id,
@@ -241,10 +238,6 @@ export const createWorkItem = (item) => {
   };
 };
 
-function isUndefined(str) {
-  return !str || str === null || str === undefined;
-}
-
-function isEmpty(str) {
-  return !str || 0 === str.length;
+function isEmptyOrUndefined(str) {
+  return !str || 0 === str.length || str == null;
 }

--- a/src/utils/releaseNoteUtil.js
+++ b/src/utils/releaseNoteUtil.js
@@ -1,36 +1,11 @@
 export const classifyReleaseNote = (note) => {
   const { title, ingress, description } = note;
-  const [hasTitle, hasIngress, hasDescription] = [
+  const [hasTitle, hasIngress] = [
     title && title.length > 0,
     ingress && ingress.length > 0,
-    hasText(description),
+    description && description.length > 0,
   ];
-  if (!hasDescription) return "NO-DESCRIPTION"; // there should always be a description
   if (!hasIngress && !hasTitle) {
     return "DENSE";
   } else return "FULL";
-};
-
-/**
- * check if html string has content
- * @param {string} str the html string
- */
-const hasText = (str) => {
-  if (str === "" || !str) return false;
-  const aux = document.createElement("div");
-  aux.innerHTML = str; //parses the html
-
-  var hasText = false;
-  aux.childNodes.forEach((child) => {
-    if (child.innerHTML?.trim().length > 0) {
-      hasText = true;
-    }
-    if (child.nodeName === "IMG") {
-      hasText = true;
-    }
-    if (child.TEXT_NODE) {
-      if (child.textContent.length > 0) hasText = true;
-    }
-  });
-  return hasText;
 };

--- a/src/utils/releaseNoteUtil.js
+++ b/src/utils/releaseNoteUtil.js
@@ -1,11 +1,34 @@
 export const classifyReleaseNote = (note) => {
   const { title, ingress, description } = note;
-  const [hasTitle, hasIngress] = [
+  const [hasTitle, hasIngress, hasDescription] = [
     title && title.length > 0,
     ingress && ingress.length > 0,
-    description && description.length > 0,
+    description && hasText(description),
   ];
-  if (!hasIngress && !hasTitle) {
-    return "DENSE";
-  } else return "FULL";
+  if (hasTitle) return "FULL";
+  return "DENSE";
+};
+
+/**
+ * check if html string has content
+ * @param {string} str the html string
+ */
+const hasText = (str) => {
+  if (str === "" || !str) return false;
+  const aux = document.createElement("div");
+  aux.innerHTML = str; //parses the html
+
+  var hasText = false;
+  aux.childNodes.forEach((child) => {
+    if (child.innerHTML?.trim().length > 0) {
+      hasText = true;
+    }
+    if (child.nodeName === "IMG") {
+      hasText = true;
+    }
+    if (child.TEXT_NODE) {
+      if (child.textContent.length > 0) hasText = true;
+    }
+  });
+  return hasText;
 };

--- a/src/utils/releaseNoteUtil.test.js
+++ b/src/utils/releaseNoteUtil.test.js
@@ -38,7 +38,7 @@ describe("releaseNoteUtil", () => {
       description: "<p></p><p></p><p></p>",
     };
     const result = classifyReleaseNote(note);
-    expect(result).toEqual("NO-DESCRIPTION");
+    expect(result).toEqual("DENSE");
   });
 
   it("is not undefined when a tag has text ", () => {
@@ -57,7 +57,7 @@ describe("releaseNoteUtil", () => {
       description: undefined,
     };
     const result = classifyReleaseNote(note);
-    expect(result).toEqual("NO-DESCRIPTION");
+    expect(result).toEqual("DENSE");
   });
   it("returns dense", () => {
     const note = {

--- a/src/utils/releaseNoteUtil.test.js
+++ b/src/utils/releaseNoteUtil.test.js
@@ -31,15 +31,6 @@ describe("releaseNoteUtil", () => {
     const result = classifyReleaseNote(note);
     expect(result).toEqual("FULL");
   });
-  it("is undefined when description only has empty html tags", () => {
-    const note = {
-      title: "",
-      ingress: "",
-      description: "<p></p><p></p><p></p>",
-    };
-    const result = classifyReleaseNote(note);
-    expect(result).toEqual("DENSE");
-  });
 
   it("is not undefined when a tag has text ", () => {
     const note = {
@@ -50,15 +41,7 @@ describe("releaseNoteUtil", () => {
     const result = classifyReleaseNote(note);
     expect(result).toEqual("FULL");
   });
-  it("works with undefined fields ", () => {
-    const note = {
-      title: undefined,
-      ingress: undefined,
-      description: undefined,
-    };
-    const result = classifyReleaseNote(note);
-    expect(result).toEqual("DENSE");
-  });
+
   it("returns dense", () => {
     const note = {
       title: undefined,


### PR DESCRIPTION
Grunnen til blank release notes var at work items ikke inkluderte feltet for descriptions. Dette er nå korrigert. 

![bilde](https://user-images.githubusercontent.com/26660106/80959853-f4ba8080-8e07-11ea-8986-d5798808df66.png)
